### PR TITLE
Ensure errors are logged regardless of if they have a stack

### DIFF
--- a/content/notero.ts
+++ b/content/notero.ts
@@ -1,6 +1,7 @@
 import { NoteroPref } from './types';
 import NoteroItem from './notero-item';
 import Notion from './notion';
+import { hasErrorStack } from './utils';
 
 const monkey_patch_marker = 'NoteroMonkeyPatched';
 
@@ -129,8 +130,9 @@ class Notero {
       }
     } catch (error) {
       const errorMessage = String(error);
-      if (error instanceof Error) {
-        Zotero.log(`${errorMessage}\n${error.stack}`, 'error');
+      Zotero.log(errorMessage, 'error');
+      if (hasErrorStack(error)) {
+        Zotero.log(error.stack, 'error');
       }
       Zotero.alert(window, 'Failed to save item(s) to Notion', errorMessage);
     } finally {

--- a/content/utils.ts
+++ b/content/utils.ts
@@ -1,0 +1,3 @@
+export function hasErrorStack(error: unknown): error is Required<Error> {
+  return typeof (error as Error).stack !== 'undefined';
+}


### PR DESCRIPTION
This should hopefully help with debugging in the future.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)