### PR TITLE
Sync items when modified and update existing Notion pages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,3 @@ build
 gen
 node_modules
 esbuild.js
-*.d.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,19 +61,7 @@
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/dot-notation": "error",
     "@typescript-eslint/explicit-module-boundary-types": "warn",
-    "@typescript-eslint/member-delimiter-style": [
-      "error",
-      {
-        "multiline": {
-          "delimiter": "semi",
-          "requireLast": true
-        },
-        "singleline": {
-          "delimiter": "comma",
-          "requireLast": false
-        }
-      }
-    ],
+    "@typescript-eslint/member-delimiter-style": "error",
     "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/no-array-constructor": "error",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ when added to a specific collection.
 
 ![Notero in action](docs/notero.gif)
 
-## Why use Notero?
+## Why Use Notero?
 
 - Allows you to integrate your reference manager, task list, reading notes,
   analytical tables, and drafts in one location.
@@ -18,6 +18,35 @@ when added to a specific collection.
   a reference.
 - Link references to entries in other databases, such as projects, tasks,
   manuscripts in your publication pipeline, publishing outlets, etc.
+
+## How Notero Works
+
+The Notero plugin watches for Zotero items being added to a collection that you
+specify in the Notero preferences. Whenever an item is added to the collection,
+Notero does a few things:
+
+- Save a page with the Zotero item's properties (title, authors, etc.) into the
+  Notion database specified in Notero preferences.
+- Add a `notion` tag to the Zotero item.
+- Add an attachment to the Zotero item that links to the page in Notion.
+
+In addition to providing a convenient way to open a Notion page from Zotero,
+the link attachment also serves as a reference for Notero so it can update
+existing pages instead of creating duplicate pages for a given Zotero item.
+
+### Syncing Items
+
+Because Zotero does not allow you to add an item to a collection that it's
+already in, there are a couple options for triggering a re-sync of an item:
+
+- Remove the item from the collection and add it again.
+- Enable the **Sync when items are modified** option in Notero preferences to
+  sync items in the collection whenever they're modified.
+
+⚠️ _**Note:** To prevent the "sync on modify" functionality from saving to Notion
+multiple times, Notero does not notify Zotero when the tag and link attachment
+are added to an item. This means they may not appear in Zotero immediately, and
+you may need to navigate to a different item and back to make them appear._
 
 ## Installation and Setup
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ the other properties must be configured exactly as specified here.
 | `Full Citation`    | Text          | No       |
 | `In-Text Citation` | Text          | No       |
 
-### Install Notero Plugin
+### Install and Configure Notero Plugin
 
 1. Download the [latest version](https://github.com/dvanoni/notero/releases/latest)
    of the `.xpi` file.
@@ -93,17 +93,8 @@ the other properties must be configured exactly as specified here.
    - selecting it using the **Install Add-on From File...** option in the
      gear menu in the top-right corner of the window
 1. Restart Zotero to activate the plugin.
-
-### Configure Notero Preferences
-
-1.  Open the Notero preferences from the **Tools → Notero Preferences...** menu item.
-1.  Enter the required preferences:
-
-    | Field                    | Description                                            |
-    | ------------------------ | ------------------------------------------------------ |
-    | Collection Name          | Name of the Zotero collection to monitor for new items |
-    | Notion Integration Token | Your personal Notion internal integration token        |
-    | Notion Database ID       | ID of the Notion database to sync items into           |
+1. Open the Notero preferences from the **Tools → Notero Preferences...** menu
+   item, and enter the required preferences.
 
 ## Example Notion Databases
 

--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -102,6 +102,11 @@ export default class NoteroItem {
     );
   }
 
+  public getNotionPageID(): string | undefined {
+    const notionURL = this.getNotionLinkAttachments()[0]?.getField('url');
+    return notionURL && Notion.getPageIDFromURL(notionURL);
+  }
+
   public async saveNotionLinkAttachment(url: string): Promise<void> {
     const notionURL = Notion.convertWebURLToLocal(url);
     const attachments = this.getNotionLinkAttachments();

--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -1,3 +1,5 @@
+import Notion from './notion';
+
 const APA_STYLE = 'bibliography=http://www.zotero.org/styles/apa';
 
 export default class NoteroItem {
@@ -86,5 +88,41 @@ export default class NoteroItem {
 
   public get zoteroURI(): string {
     return Zotero.URI.getItemURI(this.zoteroItem);
+  }
+
+  public getNotionLinkAttachments(): Zotero.Item[] {
+    const attachmentIDs = this.zoteroItem
+      .getAttachments(false)
+      .slice()
+      // Sort to get largest ID first
+      .sort((a, b) => b - a);
+
+    return Zotero.Items.get(attachmentIDs).filter((attachment) =>
+      attachment.getField('url')?.startsWith(Notion.URL_PROTOCOL)
+    );
+  }
+
+  public async saveNotionLinkAttachment(url: string): Promise<void> {
+    const notionURL = Notion.convertWebURLToLocal(url);
+    const attachments = this.getNotionLinkAttachments();
+
+    if (attachments.length > 1) {
+      const attachmentIDs = attachments.slice(1).map(({ id }) => id);
+      await Zotero.Items.erase(attachmentIDs);
+    }
+
+    if (attachments.length > 0) {
+      attachments[0].setField('url', notionURL);
+      await attachments[0].saveTx();
+    } else {
+      await Zotero.Attachments.linkFromURL({
+        parentItemID: this.zoteroItem.id,
+        title: 'Notion',
+        url: notionURL,
+        saveOptions: {
+          skipNotifier: true,
+        },
+      });
+    }
   }
 }

--- a/content/notero.ts
+++ b/content/notero.ts
@@ -145,16 +145,13 @@ class Notero {
   }
 
   private async saveItemToNotion(item: Zotero.Item, notion: Notion) {
-    const response = await notion.addItemToDatabase(new NoteroItem(item));
+    const noteroItem = new NoteroItem(item);
+    const response = await notion.addItemToDatabase(noteroItem);
 
     item.addTag('notion');
     await item.saveTx();
 
-    await Zotero.Attachments.linkFromURL({
-      url: Notion.convertWebURLToLocal(response.url),
-      parentItemID: item.id,
-      title: 'Notion',
-    });
+    await noteroItem.saveNotionLinkAttachment(response.url);
   }
 }
 

--- a/content/notero.ts
+++ b/content/notero.ts
@@ -171,12 +171,14 @@ class Notero {
 
   private async saveItemToNotion(item: Zotero.Item, notion: Notion) {
     const noteroItem = new NoteroItem(item);
-    const response = await notion.addItemToDatabase(noteroItem);
+    const response = await notion.saveItemToDatabase(noteroItem);
 
     item.addTag('notion');
     await item.saveTx({ skipNotifier: true });
 
-    await noteroItem.saveNotionLinkAttachment(response.url);
+    if ('url' in response) {
+      await noteroItem.saveNotionLinkAttachment(response.url);
+    }
   }
 }
 

--- a/content/notero.ts
+++ b/content/notero.ts
@@ -1,6 +1,6 @@
-import { NoteroPref } from './types';
 import NoteroItem from './notero-item';
 import Notion from './notion';
+import { NoteroPref } from './types';
 import { hasErrorStack } from './utils';
 
 const monkey_patch_marker = 'NoteroMonkeyPatched';
@@ -29,7 +29,7 @@ class Notero {
 
     const notifierID = Zotero.Notifier.registerObserver(
       this.notifierCallback,
-      ['collection-item'],
+      ['collection-item', 'item'],
       'notero'
     );
 
@@ -49,23 +49,15 @@ class Notero {
       ids: string[],
       _: Record<string, unknown>
     ) => {
-      if (event !== 'add' || type !== 'collection-item') return;
+      const syncOnModifyItems =
+        this.getPref(NoteroPref.syncOnModifyItems) === true;
 
-      const collectionName = this.getPref(NoteroPref.collectionName);
-      if (!collectionName) return;
-
-      const itemIDs = ids
-        .map((collectionItem: string) => {
-          const [collectionID, itemID] = collectionItem.split('-').map(Number);
-          return { collectionID, itemID };
-        })
-        .filter(({ collectionID }) => {
-          const collection = Zotero.Collections.get(collectionID);
-          return collection?.name === collectionName;
-        })
-        .map(({ itemID }) => itemID);
-
-      this.onAddItemsToCollection(itemIDs);
+      if (!syncOnModifyItems && event === 'add' && type === 'collection-item') {
+        return this.onAddItemsToCollection(ids);
+      }
+      if (syncOnModifyItems && event === 'modify' && type === 'item') {
+        return this.onModifyItems(ids);
+      }
     },
   };
 
@@ -85,9 +77,40 @@ class Notero {
     return Zotero.Prefs.get(`extensions.notero.${pref}`, true);
   }
 
-  private onAddItemsToCollection(itemIDs: number[]) {
-    const items = Zotero.Items.get(itemIDs).filter((item) =>
-      item.isRegularItem()
+  private onAddItemsToCollection(ids: string[]) {
+    const collectionName = this.getPref(NoteroPref.collectionName);
+    if (!collectionName) return;
+
+    const items = ids
+      .map((collectionItem: string) => {
+        const [collectionID, itemID] = collectionItem.split('-').map(Number);
+        return {
+          collection: Zotero.Collections.get(collectionID),
+          item: Zotero.Items.get(itemID),
+        };
+      })
+      .filter(
+        (
+          record
+        ): record is { collection: Zotero.Collection; item: Zotero.Item } =>
+          record.collection &&
+          record.collection.name === collectionName &&
+          record.item &&
+          record.item.isRegularItem()
+      )
+      .map(({ item }) => item);
+
+    void this.saveItemsToNotion(items);
+  }
+
+  private onModifyItems(ids: string[]) {
+    const collectionName = this.getPref(NoteroPref.collectionName);
+    if (typeof collectionName !== 'string' || !collectionName) return;
+
+    const items = Zotero.Items.get(ids.map(Number)).filter((item) =>
+      Zotero.Collections.get(item.getCollections())
+        .map(({ name }) => name)
+        .includes(collectionName)
     );
 
     void this.saveItemsToNotion(items);
@@ -114,6 +137,8 @@ class Notero {
 
   private async saveItemsToNotion(items: Zotero.Item[]) {
     const PERCENTAGE_MULTIPLIER = 100;
+
+    if (!items.length) return;
 
     try {
       const notion = this.getNotion();
@@ -149,7 +174,7 @@ class Notero {
     const response = await notion.addItemToDatabase(noteroItem);
 
     item.addTag('notion');
-    await item.saveTx();
+    await item.saveTx({ skipNotifier: true });
 
     await noteroItem.saveNotionLinkAttachment(response.url);
   }

--- a/content/notion.ts
+++ b/content/notion.ts
@@ -39,6 +39,8 @@ export default class Notion {
   private readonly databaseID: string;
   private _databaseProperties?: DatabaseProperties;
 
+  static URL_PROTOCOL = 'notion:';
+
   static logger: Logger = (level, message, extraInfo) => {
     Zotero.log(
       `${message} - ${JSON.stringify(extraInfo)}`,
@@ -57,7 +59,7 @@ export default class Notion {
   }
 
   static convertWebURLToLocal(url: string): string {
-    return url.replace(/^https/, 'notion');
+    return url.replace(/^https:/, this.URL_PROTOCOL);
   }
 
   static truncateTextToMaxLength(str: string): string {
@@ -106,11 +108,8 @@ export default class Notion {
 
     const databaseProperties = await this.getDatabaseProperties();
 
-    const databaseHasProperty = ({ name, type }: Definition) => {
-      const has = databaseProperties[name]?.type === type;
-      Zotero.log(`Database has '${name}': ${has}`, 'warning');
-      return has;
-    };
+    const databaseHasProperty = ({ name, type }: Definition) =>
+      databaseProperties[name]?.type === type;
 
     const itemProperties: DatabasePageProperties = {
       title: {

--- a/content/preferences.js
+++ b/content/preferences.js
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unused-vars,no-undef */
+
+function openReadme() {
+  Zotero.getActiveZoteroPane().loadURI(
+    'https://github.com/dvanoni/notero#readme'
+  );
+}

--- a/content/preferences.xul
+++ b/content/preferences.xul
@@ -13,18 +13,37 @@
       <preference id="pref-collectionName" name="extensions.notero.collectionName" type="string" />
       <preference id="pref-notionToken" name="extensions.notero.notionToken" type="string" />
       <preference id="pref-notionDatabaseID" name="extensions.notero.notionDatabaseID" type="string" />
+      <preference id="pref-syncOnModifyItems" name="extensions.notero.syncOnModifyItems" type="bool" />
     </preferences>
 
-    <label id="notero-collectionName-label" value="&notero.preferences.collectionName;" control="notero-collectionName" />
-    <textbox id="notero-collectionName" preference="pref-collectionName" />
+    <groupbox>
+      <caption label="&notero.preferences.syncGroupCaption;" />
+      <description>&notero.preferences.syncGroupDescription;</description>
+      <separator />
+      <label id="notero-collectionName-label" value="&notero.preferences.collectionName;" control="notero-collectionName" />
+      <textbox id="notero-collectionName" preference="pref-collectionName" />
+      <separator />
+      <checkbox id="notero-syncOnModifyItems" label="&notero.preferences.syncOnModifyItems;" preference="pref-syncOnModifyItems" />
+    </groupbox>
+
     <separator />
 
-    <label id="notero-notionToken-label" value="&notero.preferences.notionToken;" control="notero-notionToken" />
-    <textbox id="notero-notionToken" preference="pref-notionToken" />
-    <separator />
-
-    <label id="notero-notionDatabaseID-label" value="&notero.preferences.notionDatabaseID;" control="notero-notionDatabaseID" />
-    <textbox id="notero-notionDatabaseID" preference="pref-notionDatabaseID" />
-    <separator />
+    <groupbox style="margin-bottom: 4em;">
+      <caption label="&notero.preferences.notionGroupCaption;" />
+      <hbox>
+        <description style="margin-right: 0;" value="&notero.preferences.notionGroupDescription;" />
+        <description class="text-link" onclick="openReadme();" style="margin-left: 0; margin-right: 0;" value="&notero.preferences.readme;" />
+        <description style="margin-left: 0;" value="." />
+      </hbox>
+      <separator />
+      <label id="notero-notionToken-label" value="&notero.preferences.notionToken;" control="notero-notionToken" />
+      <textbox id="notero-notionToken" preference="pref-notionToken" />
+      <separator />
+      <label id="notero-notionDatabaseID-label" value="&notero.preferences.notionDatabaseID;" control="notero-notionDatabaseID" />
+      <textbox id="notero-notionDatabaseID" preference="pref-notionDatabaseID" />
+    </groupbox>
   </prefpane>
+
+  <script src="chrome://zotero/content/include.js" />
+  <script src="preferences.js" />
 </prefwindow>

--- a/content/types.ts
+++ b/content/types.ts
@@ -2,4 +2,5 @@ export enum NoteroPref {
   collectionName = 'collectionName',
   notionToken = 'notionToken',
   notionDatabaseID = 'notionDatabaseID',
+  syncOnModifyItems = 'syncOnModifyItems',
 }

--- a/defaults/preferences/notero.js
+++ b/defaults/preferences/notero.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-undef */
+
+pref('extensions.notero.collectionName', '');
+pref('extensions.notero.notionToken', '');
+pref('extensions.notero.notionDatabaseID', '');
+pref('extensions.notero.syncOnModifyItems', false);

--- a/locale/en-US/notero.dtd
+++ b/locale/en-US/notero.dtd
@@ -1,6 +1,15 @@
 <!ENTITY notero "Sync Zotero items into a Notion database">
+
 <!ENTITY notero.preferences.title "Notero Preferences">
 <!ENTITY notero.preferences.menuitem "Notero Preferences...">
+
+<!ENTITY notero.preferences.syncGroupCaption "Sync Preferences">
+<!ENTITY notero.preferences.syncGroupDescription "Notero will monitor the specified collection for items. Items will sync to Notion when added to the collection, and you can also enable syncing whenever an item in the collection is modified.">
 <!ENTITY notero.preferences.collectionName "Collection Name">
-<!ENTITY notero.preferences.notionToken "Notion Integration Token">
-<!ENTITY notero.preferences.notionDatabaseID "Notion Database ID">
+<!ENTITY notero.preferences.syncOnModifyItems "Sync when items are modified">
+
+<!ENTITY notero.preferences.notionGroupCaption "Notion Preferences">
+<!ENTITY notero.preferences.notionGroupDescription "To see how to obtain these values, view the ">
+<!ENTITY notero.preferences.readme "README">
+<!ENTITY notero.preferences.notionToken "Integration Token">
+<!ENTITY notero.preferences.notionDatabaseID "Database ID">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
-        "@notionhq/client": "^0.4.10",
+        "@notionhq/client": "https://github.com/dvanoni/notion-sdk-js/releases/download/v0.4.12-dvanoni/notionhq-client-0.4.12-dvanoni.tgz",
         "@typescript-eslint/eslint-plugin": "^4.31.2",
         "@typescript-eslint/parser": "^4.31.2",
         "core-js": "^3.18.0",
@@ -639,9 +639,10 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-0.4.10.tgz",
-      "integrity": "sha512-s+a+q7FNrum4KsAPLt4tWMePKjLydtid6/7NVUZ9Do9w8PHMER5G2Boj92v6AbQVJxX0nwQ4e4CeJBV0kS73eQ==",
+      "version": "0.4.12-dvanoni",
+      "resolved": "https://github.com/dvanoni/notion-sdk-js/releases/download/v0.4.12-dvanoni/notionhq-client-0.4.12-dvanoni.tgz",
+      "integrity": "sha512-iYfgvKCJ8V3avHcdDvLuM3WMWbVDg3rK3f5y/Lnx+yNHsVGOqw40JrsdEoejPg4KUWQSudu37/c1skVvrUvNGw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
@@ -6885,9 +6886,8 @@
       }
     },
     "@notionhq/client": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-0.4.10.tgz",
-      "integrity": "sha512-s+a+q7FNrum4KsAPLt4tWMePKjLydtid6/7NVUZ9Do9w8PHMER5G2Boj92v6AbQVJxX0nwQ4e4CeJBV0kS73eQ==",
+      "version": "https://github.com/dvanoni/notion-sdk-js/releases/download/v0.4.12-dvanoni/notionhq-client-0.4.12-dvanoni.tgz",
+      "integrity": "sha512-iYfgvKCJ8V3avHcdDvLuM3WMWbVDg3rK3f5y/Lnx+yNHsVGOqw40JrsdEoejPg4KUWQSudu37/c1skVvrUvNGw==",
       "requires": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
-    "@notionhq/client": "^0.4.10",
+    "@notionhq/client": "https://github.com/dvanoni/notion-sdk-js/releases/download/v0.4.12-dvanoni/notionhq-client-0.4.12-dvanoni.tgz",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.31.2",
     "core-js": "^3.18.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,12 @@
     "lib": ["es2017", "dom"],
     "typeRoots": ["./typings", "./node_modules/@types"]
   },
-  "include": ["content/**/*", "resource/**/*", "typings/**/*", "*.ts"],
+  "include": [
+    "content/**/*",
+    "defaults/**/*",
+    "resource/**/*",
+    "typings/**/*",
+    "*.ts"
+  ],
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -10,10 +10,10 @@ declare namespace Zotero {
      */
     linkFromURL(options: {
       url: string;
-      parentItemID: number;
+      parentItemID: DataObjectID;
       contentType?: string;
       title?: string;
-      collections?: (number | string)[];
+      collections?: (DataObjectID | DataObjectKey)[];
       saveOptions?: DataObject.SaveOptions;
     }): Promise<Zotero.Item>;
   }
@@ -24,15 +24,18 @@ declare namespace Zotero {
 
   type Collections = DataObjects<Collection>;
 
+  type DataObjectID = number;
+  type DataObjectKey = string;
+
   interface DataObject {
-    id: number;
-    key: string;
+    id: DataObjectID;
+    key: DataObjectKey;
 
     /**
      * Save changes to database.
      * @return Promise for itemID of new item, TRUE on item update, or FALSE if item was unchanged
      */
-    saveTx(options?: DataObject.SaveOptions): Promise<boolean | number>;
+    saveTx(options?: DataObject.SaveOptions): Promise<boolean | DataObjectID>;
   }
 
   namespace DataObject {
@@ -51,7 +54,9 @@ declare namespace Zotero {
   }
 
   interface DataObjects<T extends DataObject> {
-    get<I = number | number[]>(ids: I): I extends number ? T | undefined : T[];
+    get<I = DataObjectID | DataObjectID[]>(
+      ids: I
+    ): I extends DataObjectID ? T | undefined : T[];
   }
 
   interface Item extends DataObject {

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -102,6 +102,8 @@ declare namespace Zotero {
 
     getAttachments(includeTrashed: boolean): DataObjectID[];
 
+    getCollections(): DataObjectID[];
+
     getCreators(): { firstName: string; lastName: string }[];
 
     getDisplayTitle(includeAuthorAndDate?: boolean): string;
@@ -224,6 +226,10 @@ declare namespace Zotero {
   interface URI {
     getItemURI(item: Item): string;
   }
+
+  interface ZoteroPane {
+    loadURI(uris: string | string[]): void;
+  }
 }
 
 // eslint-disable-next-line no-redeclare
@@ -248,6 +254,8 @@ declare const Zotero: {
     message: string,
     type: 'error' | 'warning' | 'exception' | 'strict'
   ): void;
+
+  getActiveZoteroPane(): Zotero.ZoteroPane | null;
 
   /**
    * Show Zotero pane overlay and progress bar in all windows

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable id-blacklist */
+
 declare namespace Zotero {
   interface Attachments {
     /**
@@ -20,7 +22,7 @@ declare namespace Zotero {
     name: string;
   }
 
-  interface Collections extends DataObjects<Collection> {}
+  type Collections = DataObjects<Collection>;
 
   interface DataObject {
     id: number;
@@ -79,7 +81,7 @@ declare namespace Zotero {
     isRegularItem(): boolean;
   }
 
-  interface Items extends DataObjects<Item> {}
+  type Items = DataObjects<Item>;
 
   interface ItemTypes {
     getLocalizedString(idOrName: number | string): string;
@@ -188,6 +190,7 @@ declare namespace Zotero {
   }
 }
 
+// eslint-disable-next-line no-redeclare
 declare const Zotero: {
   Attachments: Zotero.Attachments;
   Collections: Zotero.Collections;


### PR DESCRIPTION
Add the option to sync items when modified. When saving to Notion, update exiting pages instead of creating duplicate pages.

In order for page updates to work properly, this requires a custom build of [notion-sdk-js](https://github.com/makenotion/notion-sdk-js) with a fix for the `method` passed to `fetch()`. (see https://github.com/dvanoni/notion-sdk-js/releases/tag/v0.4.12-dvanoni)

Closes #10