### PR TITLE
Add support for Zotero's Date property

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ the other properties must be configured exactly as specified here.
 | `Name`             | Title         | Currently formatted as a citation, but see issue [#14](https://github.com/dvanoni/notero/issues/14) |
 | `Abstract`         | Text          |                                                                                                     |
 | `Authors`          | Text          |                                                                                                     |
+| `Date`             | Text          |
 | `DOI`              | URL           |                                                                                                     |
 | `Editors`          | Text          |                                                                                                     |
 | `File Path`        | Text          |                                                                                                     |

--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -126,6 +126,10 @@ export default class NoteroItem {
     return Number.isNaN(year) ? null : year;
   }
 
+  public getDate(): string {
+    return this.zoteroItem.getField('date') || '';
+  }
+
   public getZoteroURI(): string {
     return Zotero.URI.getItemURI(this.zoteroItem);
   }

--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -126,8 +126,8 @@ export default class NoteroItem {
     return Number.isNaN(year) ? null : year;
   }
 
-  public getDate(): string {
-    return this.zoteroItem.getField('date') || '';
+  public getDate(): string | null {
+    return this.zoteroItem.getField('date') || null;
   }
 
   public getZoteroURI(): string {

--- a/content/notion.ts
+++ b/content/notion.ts
@@ -229,6 +229,11 @@ export default class Notion {
         buildRequest: () => item.getYear(),
       },
       {
+        name: 'Date',
+        type: 'rich_text',
+        buildRequest: () => Notion.buildRichText(item.getDate()),
+      },
+      {
         name: 'Zotero URI',
         type: 'url',
         buildRequest: () => item.getZoteroURI(),


### PR DESCRIPTION
* Followed same approach as https://github.com/dvanoni/notero/pull/35
* Tested locally and confirmed to be working
* Went with a text type for the date instead of a date type because Zotero itself doesn't store that property as a date
  * For example, my test entries (journal articles) included dates of `2022-05`
  * It makes the most sense for users to use a formula column on the Notion side to parse the date strings