### PR TITLE
Adding ability to embed PDFs in Notion using Zotero Web API

### DIFF
--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -1,5 +1,5 @@
 import Notion from './notion';
-import NoteroPref from './notero-pref';
+import { NoteroPref, getNoteroPref } from './notero-pref';
 
 const APA_STYLE = 'bibliography=http://www.zotero.org/styles/apa';
 
@@ -135,19 +135,25 @@ export default class NoteroItem {
     return Zotero.URI.getItemURI(this.zoteroItem);
   }
 
-  public getPDFURL(): string | null {
+  public getPDFURL(): string {
     const zoteroAPIKey = getNoteroPref(NoteroPref.zoteroAPIKey);
+    const zoteroUserID = getNoteroPref(NoteroPref.zoteroUserID);
+    const attachmentIDs = this.zoteroItem
+      .getAttachments(false)
+      .slice()
+      // Sort to get largest ID first
+      .sort((a, b) => b - a);
 
-    const attachment = await this.zoteroItem.getBestAttachment();
-    if (!attachment) return null;
-    if (attachment.attachmentContentType != 'application/pdf') return null;
-    
-    const zoteroURI = Zotero.URI.getItemURI(attachment);
-    const temp = zoteroURI.split('/').slice(2).join('/');
-    const prefix = 'https://api.';
-    const requestURL = prefix.concat(temp, '/file/view?key=', zoteroAPIKey);
-    return requestURL;
+    for (const id of attachmentIDs) {
+      const attachment = Zotero.Items.get(id);
+      if (attachment.attachmentContentType == 'application/pdf') {
+        const pdfItemID = Zotero.URI.getItemURI(attachment).split('/').pop();
+        return `https://api.zotero.org/users/${zoteroUserID}/items/${pdfItemID}/file/view?key=${zoteroAPIKey}`;
+      }
+    }
+    return 'https://zotero.org';
   }
+
 
   public getNotionLinkAttachments(): Zotero.Item[] {
     const attachmentIDs = this.zoteroItem

--- a/content/notero-item.ts
+++ b/content/notero-item.ts
@@ -1,4 +1,5 @@
 import Notion from './notion';
+import NoteroPref from './notero-pref';
 
 const APA_STYLE = 'bibliography=http://www.zotero.org/styles/apa';
 
@@ -132,6 +133,20 @@ export default class NoteroItem {
 
   public getZoteroURI(): string {
     return Zotero.URI.getItemURI(this.zoteroItem);
+  }
+
+  public getPDFURL(): string | null {
+    const zoteroAPIKey = getNoteroPref(NoteroPref.zoteroAPIKey);
+
+    const attachment = await this.zoteroItem.getBestAttachment();
+    if (!attachment) return null;
+    if (attachment.attachmentContentType != 'application/pdf') return null;
+    
+    const zoteroURI = Zotero.URI.getItemURI(attachment);
+    const temp = zoteroURI.split('/').slice(2).join('/');
+    const prefix = 'https://api.';
+    const requestURL = prefix.concat(temp, '/file/view?key=', zoteroAPIKey);
+    return requestURL;
   }
 
   public getNotionLinkAttachments(): Zotero.Item[] {

--- a/content/notero-pref.ts
+++ b/content/notero-pref.ts
@@ -4,6 +4,7 @@ export enum NoteroPref {
   notionDatabaseID = 'notionDatabaseID',
   notionToken = 'notionToken',
   syncOnModifyItems = 'syncOnModifyItems',
+  zoteroUserID = 'zoteroUserID',
   zoteroAPIKey = 'zoteroAPIKey',
 }
 
@@ -12,8 +13,9 @@ type NoteroPrefValue = Partial<{
   [NoteroPref.collectionSyncConfigs]: string;
   [NoteroPref.notionDatabaseID]: string;
   [NoteroPref.notionToken]: string;
-  [NoteroPref.syncOnModifyItems]: boolean;
   [NoteroPref.zoteroAPIKey]: string;
+  [NoteroPref.zoteroUserID]: string;
+  [NoteroPref.syncOnModifyItems]: boolean;
 }>;
 
 function buildFullPrefName(pref: NoteroPref): string {
@@ -37,8 +39,9 @@ export function getNoteroPref<P extends NoteroPref>(
     [NoteroPref.collectionSyncConfigs]: stringPref,
     [NoteroPref.notionDatabaseID]: stringPref,
     [NoteroPref.notionToken]: stringPref,
-    [NoteroPref.syncOnModifyItems]: booleanPref,
     [NoteroPref.zoteroAPIKey]: stringPref,
+    [NoteroPref.zoteroUserID]: stringPref,
+    [NoteroPref.syncOnModifyItems]: booleanPref,
   }[pref];
 }
 

--- a/content/notero-pref.ts
+++ b/content/notero-pref.ts
@@ -4,6 +4,7 @@ export enum NoteroPref {
   notionDatabaseID = 'notionDatabaseID',
   notionToken = 'notionToken',
   syncOnModifyItems = 'syncOnModifyItems',
+  zoteroAPIKey = 'zoteroAPIKey',
 }
 
 type NoteroPrefValue = Partial<{
@@ -12,6 +13,7 @@ type NoteroPrefValue = Partial<{
   [NoteroPref.notionDatabaseID]: string;
   [NoteroPref.notionToken]: string;
   [NoteroPref.syncOnModifyItems]: boolean;
+  [NoteroPref.zoteroAPIKey]: string;
 }>;
 
 function buildFullPrefName(pref: NoteroPref): string {
@@ -36,6 +38,7 @@ export function getNoteroPref<P extends NoteroPref>(
     [NoteroPref.notionDatabaseID]: stringPref,
     [NoteroPref.notionToken]: stringPref,
     [NoteroPref.syncOnModifyItems]: booleanPref,
+    [NoteroPref.zoteroAPIKey]: stringPref,
   }[pref];
 }
 

--- a/content/notero.ts
+++ b/content/notero.ts
@@ -287,6 +287,8 @@ class Notero {
 
     if ('url' in response) {
       await noteroItem.saveNotionLinkAttachment(response.url);
+      const pageID = Notion.getPageIDFromURL(Notion.convertWebURLToLocal(response.url));
+      const response_block = await notion.addEmbedToPage(noteroItem, pageID);
     }
   }
 }

--- a/content/notion.ts
+++ b/content/notion.ts
@@ -125,9 +125,20 @@ export default class Notion {
       }
     }
 
+    const page_content = {
+      "children": [
+        {
+            "object": "block",
+            "type": "embed",
+            "embed": {"url": item.getPDFURL()}
+        },
+      ]
+    }
+
     return this.client.pages.create({
       parent: { database_id: this.databaseID },
       properties,
+      page_content,
     });
   }
 

--- a/content/notion.ts
+++ b/content/notion.ts
@@ -10,6 +10,9 @@ import {
   CreatePageResponse,
   GetDatabaseResponse,
   UpdatePageResponse,
+  AppendBlockChildrenParameters,
+  AppendBlockChildrenResponse,
+  UpdateBlockResponse
 } from '@notionhq/client/build/src/api-endpoints';
 import 'core-js/stable/object/from-entries';
 import NoteroItem from './notero-item';
@@ -125,20 +128,9 @@ export default class Notion {
       }
     }
 
-    const page_content = {
-      "children": [
-        {
-            "object": "block",
-            "type": "embed",
-            "embed": {"url": item.getPDFURL()}
-        },
-      ]
-    }
-
     return this.client.pages.create({
       parent: { database_id: this.databaseID },
       properties,
-      page_content,
     });
   }
 
@@ -249,6 +241,11 @@ export default class Notion {
         type: 'url',
         buildRequest: () => item.getZoteroURI(),
       },
+      {
+        name: 'File URL',
+        type: 'url',
+        buildRequest: () => item.getPDFURL(),
+      },
     ];
 
     const validPropertyDefinitions =
@@ -265,4 +262,22 @@ export default class Notion {
 
     return itemProperties;
   }
+
+  public async addEmbedToPage(
+    item: NoteroItem,
+    pageID: string
+  ): Promise<AppendBlockChildrenResponse> {
+    const children = [
+        {
+            "object": "block",
+            "type": "embed",
+            "embed": {"url": item.getPDFURL()},
+        },
+      ];
+    
+    return await this.client.blocks.children.append({ block_id: pageID, children });
+  
+
+  }
+  
 }

--- a/content/preferences.xul
+++ b/content/preferences.xul
@@ -42,6 +42,11 @@
              value="&notero.preferences.notionDatabaseID;"
              control="notero-notionDatabaseID" />
       <textbox id="notero-notionDatabaseID" preference="pref-notionDatabaseID" />
+      <separator />
+      <label id="notero-zoteroAPIKey-label"
+             value="&notero.preferences.zoteroAPIKey;"
+             control="notero-zoteroAPIKey" />
+      <textbox id="notero-zoteroAPIKey" preference="pref-zoteroAPIKey" />
     </groupbox>
 
     <separator />

--- a/content/preferences.xul
+++ b/content/preferences.xul
@@ -47,6 +47,11 @@
              value="&notero.preferences.zoteroAPIKey;"
              control="notero-zoteroAPIKey" />
       <textbox id="notero-zoteroAPIKey" preference="pref-zoteroAPIKey" />
+      <separator />
+      <label id="notero-zoteroUserID-label"
+             value="&notero.preferences.zoteroUserID;"
+             control="notero-zoteroUserID" />
+      <textbox id="notero-zoteroUserID" preference="pref-zoteroUserID" />
     </groupbox>
 
     <separator />

--- a/defaults/preferences/notero.js
+++ b/defaults/preferences/notero.js
@@ -4,3 +4,4 @@ pref('extensions.notero.collectionSyncConfigs', '');
 pref('extensions.notero.notionToken', '');
 pref('extensions.notero.notionDatabaseID', '');
 pref('extensions.notero.syncOnModifyItems', true);
+pref('extensions.notero.zoteroAPIKey', '');

--- a/defaults/preferences/notero.js
+++ b/defaults/preferences/notero.js
@@ -5,3 +5,4 @@ pref('extensions.notero.notionToken', '');
 pref('extensions.notero.notionDatabaseID', '');
 pref('extensions.notero.syncOnModifyItems', true);
 pref('extensions.notero.zoteroAPIKey', '');
+pref('extensions.notero.zoteroUserID', '');

--- a/locale/en-US/notero.dtd
+++ b/locale/en-US/notero.dtd
@@ -10,6 +10,7 @@
 <!ENTITY notero.preferences.readme "README">
 <!ENTITY notero.preferences.notionToken "Integration Token">
 <!ENTITY notero.preferences.notionDatabaseID "Database ID">
+<!ENTITY notero.preferences.zoteroAPIKey "Zotero API Key">
 
 <!ENTITY notero.preferences.syncGroupboxCaption "Sync Preferences">
 <!ENTITY notero.preferences.syncGroupboxDescription1 "Notero will monitor the collections enabled below.">

--- a/locale/en-US/notero.properties
+++ b/locale/en-US/notero.properties
@@ -1,3 +1,4 @@
 notero.preferences.collectionName   = Collection Name
 notero.preferences.notionToken      = Notion Integration Token
 notero.preferences.notionDatabaseID = Notion Database ID
+notero.preferences.zoteroAPIKey     = Zotero API Key


### PR DESCRIPTION
I've added the ability to embed PDFs using the Zotero Web API. This is not ready to actually be released, there are a lot of issues that need to be fixed that I was unable to figure out:
- the preference window doesn't seem to register the entered User ID and API Key. It gives me an error that the preference value is null. I tested it using the defaults and then removed the values before committing
- there are no options to not include the embed- that would need to be added to allow people to decide whether or not to have it

I also don't think I followed appropriate conventions, since I have not used TypeScript before. I hope this isn't too much additional work for you to clean up, my motivation in doing this was mostly just to see if it would be possible. Look forward to seeing a cleaned up version of this in some future release if you think it is worth it!

Fixes #4 