### PR TITLE
feat: Sync `Collections` property to Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ property names are case-sensitive, so the capitalization must match exactly.
 | `Name`             | Title         | Format configurable via the **Notion Page Title** option in Notero preferences      |
 | `Abstract`         | Text          |                                                                                     |
 | `Authors`          | Text          |                                                                                     |
+| `Collections`      | Multi-select  |                                                                                     |
 | `Date`             | Text          |                                                                                     |
 | `DOI`              | URL           |                                                                                     |
 | `Editors`          | Text          |                                                                                     |

--- a/src/content/notero-item.ts
+++ b/src/content/notero-item.ts
@@ -1,4 +1,5 @@
 import Notion from './notion';
+import { buildCollectionFullName } from './utils';
 
 const APA_STYLE = 'bibliography=http://www.zotero.org/styles/apa';
 
@@ -47,6 +48,12 @@ export default class NoteroItem {
       .getCreators()
       .filter(({ creatorTypeID }) => creatorTypeID === primaryCreatorTypeID)
       .map(NoteroItem.formatCreatorName);
+  }
+
+  public getCollections(): string[] {
+    return Zotero.Collections.get(this.zoteroItem.getCollections()).map(
+      buildCollectionFullName
+    );
   }
 
   public getDate(): string | null {

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -21,8 +21,10 @@ export class Notero {
 
   public shutdown() {
     this.services.forEach((service) => {
-      log(`Shutting down ${service.constructor.name}`);
-      service.shutdown?.();
+      if (service.shutdown) {
+        log(`Shutting down ${service.constructor.name}`);
+        service.shutdown();
+      }
     });
   }
 }

--- a/src/content/notion.ts
+++ b/src/content/notion.ts
@@ -171,6 +171,14 @@ export default class Notion {
         buildRequest: () => Notion.buildRichText(item.getAuthors().join('\n')),
       },
       {
+        name: 'Collections',
+        type: 'multi_select',
+        buildRequest: () =>
+          item.getCollections().map((collection) => ({
+            name: Notion.sanitizeSelectOption(collection),
+          })),
+      },
+      {
         name: 'Date',
         type: 'rich_text',
         buildRequest: () => Notion.buildRichText(item.getDate()),

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -73,23 +73,23 @@ export default class SyncManager implements Service {
     notify: (
       event: string,
       type: Zotero.Notifier.Type,
-      ids: string[],
+      ids: (number | string)[],
       _: Record<string, unknown>
     ) => {
-      log(`Notified of ${event} ${type}`);
+      log(`Notified of ${event} ${type} for IDs ${JSON.stringify(ids)}`);
 
       const syncOnModifyItems = getNoteroPref(NoteroPref.syncOnModifyItems);
 
       if (!syncOnModifyItems && event === 'add' && type === 'collection-item') {
-        return this.onAddItemsToCollection(ids);
+        return this.handleAddItemsToCollection(ids as string[]);
       }
       if (syncOnModifyItems && event === 'modify' && type === 'item') {
-        return this.onModifyItems(ids);
+        return this.handleModifyItems(ids as number[]);
       }
     },
   };
 
-  private onAddItemsToCollection(ids: string[]) {
+  private handleAddItemsToCollection(ids: string[]) {
     const collectionIDs = loadSyncEnabledCollectionIDs();
     if (!collectionIDs.size) return;
 
@@ -117,11 +117,11 @@ export default class SyncManager implements Service {
     this.enqueueItemsToSync(items);
   }
 
-  private onModifyItems(ids: string[]) {
+  private handleModifyItems(ids: number[]) {
     const collectionIDs = loadSyncEnabledCollectionIDs();
     if (!collectionIDs.size) return;
 
-    const items = Zotero.Items.get(ids.map(Number)).filter(
+    const items = Zotero.Items.get(ids).filter(
       (item) =>
         !item.deleted &&
         item.isRegularItem() &&

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -72,7 +72,7 @@ export default class SyncManager implements Service {
   private observer = {
     notify: (
       event: string,
-      type: string,
+      type: Zotero.Notifier.Type,
       ids: string[],
       _: Record<string, unknown>
     ) => {

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -17,7 +17,7 @@ type QueuedSync = {
 
 export default class SyncManager implements Service {
   private static get tickIcon() {
-    return `chrome://zotero/skin/tick${Zotero.hiDPI ? '@2x' : ''}.png`;
+    return `chrome://zotero/skin/tick${Zotero.hiDPISuffix}.png`;
   }
 
   private observerID?: ReturnType<Zotero.Notifier['registerObserver']>;

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -347,6 +347,7 @@ declare interface Zotero {
   getMainWindow(): ReturnType<XPCOM.nsIWindowMediator['getMostRecentWindow']>;
 
   hiDPI: boolean;
+  hiDPISuffix: '@2x' | '';
 
   initializationPromise: Promise<void>;
 

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -166,12 +166,12 @@ declare namespace Zotero {
       ref: {
         notify(
           event: string,
-          type: string,
+          type: Notifier.Type,
           ids: (number | string)[],
           extraData: Record<string, unknown>
         ): void;
       },
-      types?: string[],
+      types?: Notifier.Type[],
       id?: string,
       priority?: number
     ): string;
@@ -180,6 +180,29 @@ declare namespace Zotero {
      * @param id observer id
      */
     unregisterObserver(id: string): void;
+  }
+
+  namespace Notifier {
+    type Type =
+      | 'api-key'
+      | 'bucket'
+      | 'collection'
+      | 'collection-item'
+      | 'feed'
+      | 'feedItem'
+      | 'file'
+      | 'group'
+      | 'item'
+      | 'item-tag'
+      | 'relation'
+      | 'search'
+      | 'setting'
+      | 'share'
+      | 'share-items'
+      | 'sync'
+      | 'tab'
+      | 'tag'
+      | 'trash';
   }
 
   namespace Plugins {


### PR DESCRIPTION
Add support for syncing a multi-select `Collections` property to Notion. Each Zotero collection that an item is in is synced to Notion as a separate multi-select option.

For sub-collections, the option names are built the same way as on the Notero preferences screen using the `▸` character to concatenate sub-collection names.

![CleanShot 2022-12-25 at 18 37 18@2x](https://user-images.githubusercontent.com/299357/209492527-23243578-590a-416a-8724-1f9d34a947c1.png)
