### PR TITLE
feat: Sync items when collections or tags are modified

### DIFF
--- a/src/content/notero-item.ts
+++ b/src/content/notero-item.ts
@@ -5,13 +5,6 @@ const APA_STYLE = 'bibliography=http://www.zotero.org/styles/apa';
 
 const PARENS_REGEX = /^\((.+)\)$/;
 
-const NOTION_LINK_NOTE = `
-<h2 style="background-color: #ff666680;">Do not delete!</h2>
-<p>This link attachment serves as a reference for
-<a href="https://github.com/dvanoni/notero">Notero</a>
-so that it can properly update the Notion page for this item.</p>
-`;
-
 export default class NoteroItem {
   static NOTION_TAG_NAME = 'notion';
 
@@ -205,7 +198,13 @@ export default class NoteroItem {
       });
     }
 
-    attachment.setNote(NOTION_LINK_NOTE);
+    attachment.setNote(`
+<h2 style="background-color: #ff666680;">Do not delete!</h2>
+<p>This link attachment serves as a reference for
+<a href="https://github.com/dvanoni/notero">Notero</a>
+so that it can properly update the Notion page for this item.</p>
+<p>Last synced: ${new Date().toLocaleString()}</p>
+`);
 
     await attachment.saveTx();
   }

--- a/src/content/utils/getAllCollectionItems.ts
+++ b/src/content/utils/getAllCollectionItems.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns an array of items in the collection and all descendant collections.
+ * Note that the resulting array may include duplicate items.
+ * @param collection The collection to get items for.
+ * @returns An array of items (which may include duplicates).
+ */
+export default function getAllCollectionItems(
+  collection: Zotero.Collection
+): Zotero.Item[] {
+  return collection
+    .getChildCollections(false)
+    .reduce(
+      (items, childCollection) =>
+        items.concat(getAllCollectionItems(childCollection)),
+      collection.getChildItems(false)
+    );
+}

--- a/src/content/utils/index.ts
+++ b/src/content/utils/index.ts
@@ -1,6 +1,7 @@
 export { default as buildCollectionFullName } from './buildCollectionFullName';
 export { default as createHTMLElement } from './createHTMLElement';
 export { default as createXULElement } from './createXULElement';
+export { default as getAllCollectionItems } from './getAllCollectionItems';
 export { default as getLocalizedString } from './getLocalizedString';
 export { default as getXULElementById } from './getXULElementById';
 export { default as hasErrorStack } from './hasErrorStack';

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -26,6 +26,28 @@ declare namespace Zotero {
     name: string;
     parentID: DataObjectID;
     parentKey: DataObjectKey;
+
+    /**
+     * Returns subcollections of this collection
+     *
+     * @param asIDs Return as collectionIDs
+     * @return Array of Zotero.Collection instances or collectionIDs
+     */
+    getChildCollections<A extends boolean>(
+      asIDs: A
+    ): A extends true ? number[] : Collection[];
+
+    /**
+     * Returns child items of this collection
+     *
+     * @param	asIDs Return as itemIDs
+     * @param	includeDeleted	Include items in Trash (default false)
+     * @return Array of Zotero.Item instances or itemIDs
+     */
+    getChildItems<A extends boolean>(
+      asIDs: A,
+      includeDeleted?: boolean
+    ): A extends true ? number[] : Item[];
   }
 
   type Collections = DataObjects<Collection>;
@@ -171,7 +193,7 @@ declare namespace Zotero {
           extraData: Record<string, unknown>
         ): void;
       },
-      types?: Notifier.Type[],
+      types?: readonly Notifier.Type[],
       id?: string,
       priority?: number
     ): string;


### PR DESCRIPTION
Previously, pages in Notion would end up with old values for the `Collections` or `Tags` properties if changes (e.g. renames) were made directly to collections or tags in Zotero. To address this, we've added listeners for additional Zotero events so that we can sync items when associated collections or tags are modified, including when collections are moved.

This PR also adds the last sync time into the note of the Notion link attachment on synced items.