### PR TITLE
feat: Add sync button to context menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 <a href="https://www.buymeacoffee.com/dvanoni"><img alt="Buy me a coffee" height="20" src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=dvanoni&button_colour=BD5FFF&font_colour=ffffff&font_family=Lato&outline_colour=000000&coffee_colour=FFDD00" /></a>
 
 Notero is a [Zotero plugin](https://www.zotero.org/support/plugins) for syncing
-items into [Notion](https://www.notion.so/Intro-to-databases-fd8cd2d212f74c50954c11086d85997e).
-To use it:
+items into [Notion](https://www.notion.so/product). To use it:
 
 1. 📔 [Configure](#configure-notion) your Notion database.
 2. 💾 [Install](#install-and-configure-notero-plugin) the Notero plugin into Zotero.
@@ -63,9 +62,12 @@ By default, Notero will sync items in your monitored collections whenever they
 are modified. You can disable this functionality by unchecking the **Sync when
 items are modified** option in Notero preferences.
 
-If you disable **Sync when items are modified** and would like to trigger a
-re-sync of an item, you can remove the item from the monitored collection and
-add it back in.
+You can also sync items from the collection or item context menus (right-click):
+
+- To sync all items in a collection, open the context menu for the collection
+  and select **Sync Items to Notion**.
+- To sync one item or multiple items, select the item(s) in the main pane, open
+  the context menu, and select **Sync to Notion**.
 
 ⚠️ _**Note:** To prevent the "sync on modify" functionality from saving to Notion
 multiple times, Notero does not notify Zotero when the tag and link attachment
@@ -232,19 +234,9 @@ For now, the best workarounds are:
 
 ### How to bulk sync existing items
 
-To sync multiple items that are already in a monitored collection, you can
-trigger a sync by adding a temporary tag to them. Create a new tag, add it to
-all the items by selecting them and dragging them onto the tag, then delete
-the tag.
-
-<details>
-  <summary>Video example of syncing multiple items</summary>
-  <video
-    controls 
-    src="https://user-images.githubusercontent.com/299357/152631566-11782b33-670d-455b-9eec-5d9ce87c810b.mp4" 
-    style="max-height:373px;"
-  />
-</details>
+To sync multiple items that are already in a monitored collection, you can do so
+from the collection or item context menus.
+See the [Syncing Items](#syncing-items) section above.
 
 ### How to fix Notion API errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@notionhq/client": "^2.2.3",
-        "core-js": "^3.27.1"
+        "core-js": "^3.27.1",
+        "eventemitter3": "^5.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.3.0",
@@ -3508,6 +3509,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
+      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
     },
     "node_modules/execa": {
       "version": "0.6.3",
@@ -9981,6 +9987,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
+      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
     },
     "execa": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "homepage": "https://github.com/dvanoni/notero",
   "dependencies": {
     "@notionhq/client": "^2.2.3",
-    "core-js": "^3.27.1"
+    "core-js": "^3.27.1",
+    "eventemitter3": "^5.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.3.0",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -51,14 +51,13 @@ async function waitForZotero() {
             .QueryInterface(Ci.nsIInterfaceRequestor)
             .getInterface(Ci.nsIDOMWindow);
           const windowListener = () => {
-            domWindow.removeEventListener('load', windowListener, false);
             if (domWindow.Zotero) {
               Services.wm.removeListener(windowMediatorListener);
               Zotero = domWindow.Zotero as typeof Zotero;
               resolve();
             }
           };
-          domWindow.addEventListener('load', windowListener, false);
+          domWindow.addEventListener('load', windowListener, { once: true });
         },
       };
       Services.wm.addListener(windowMediatorListener);

--- a/src/content/constants.ts
+++ b/src/content/constants.ts
@@ -1,0 +1,1 @@
+export const IS_ZOTERO_7 = Zotero.platformMajorVersion >= 102;

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -1,7 +1,6 @@
+import { IS_ZOTERO_7 } from './constants';
 import { Service, SyncManager, UIManager } from './services';
 import { log } from './utils';
-
-const IS_ZOTERO_7 = Zotero.platformMajorVersion >= 102;
 
 if (!IS_ZOTERO_7) {
   Cu.importGlobalProperties(['URL']);

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -1,5 +1,5 @@
 import { IS_ZOTERO_7 } from './constants';
-import { Service, SyncManager, UIManager } from './services';
+import { EventManager, Service, SyncManager, UIManager } from './services';
 import { log } from './utils';
 
 if (!IS_ZOTERO_7) {
@@ -7,7 +7,11 @@ if (!IS_ZOTERO_7) {
 }
 
 export class Notero {
-  private readonly services: Service[] = [new SyncManager(), new UIManager()];
+  private readonly services: Service[] = [
+    new EventManager(),
+    new SyncManager(),
+    new UIManager(),
+  ];
 
   public async startup(pluginID: string, rootURI: string) {
     await Zotero.uiReadyPromise;

--- a/src/content/services/event-manager.ts
+++ b/src/content/services/event-manager.ts
@@ -33,6 +33,8 @@ export type NotifierEventParams = Parameters<NotifierEventListener>;
 
 type EventTypes = {
   'notifier-event': NotifierEventListener;
+  'request-sync-collection': (collection: Zotero.Collection) => void;
+  'request-sync-items': (items: Zotero.Item[]) => void;
 };
 
 const emitter = new EventEmitter<EventTypes>();
@@ -40,6 +42,7 @@ const emitter = new EventEmitter<EventTypes>();
 export default class EventManager implements Service {
   static readonly emit = emitter.emit.bind(emitter);
   static readonly addListener = emitter.addListener.bind(emitter);
+  static readonly removeListener = emitter.removeListener.bind(emitter);
 
   private observerID?: ReturnType<Zotero.Notifier['registerObserver']>;
 

--- a/src/content/services/event-manager.ts
+++ b/src/content/services/event-manager.ts
@@ -1,0 +1,110 @@
+import EventEmitter from 'eventemitter3';
+
+import { log } from '../utils';
+
+import type { Service } from './service';
+
+type CollectionID = Zotero.Collection['id'];
+type ItemID = Zotero.Item['id'];
+type TagID = Zotero.DataObjectID;
+
+type NotifierIDs = readonly (number | string)[];
+
+type NotifierEvents = {
+  'collection.delete': CollectionID[];
+  'collection.modify': CollectionID[];
+  'collection-item.add': [collectionID: CollectionID, itemID: ItemID][];
+  'item.modify': ItemID[];
+  'item-tag.modify': [itemID: ItemID, tagID: TagID][];
+  'item-tag.remove': [itemID: ItemID, tagID: TagID][];
+};
+
+type NotifierEventName = keyof NotifierEvents;
+
+type NotifierEventsMap = {
+  [E in NotifierEventName]: [event: E, ids: NotifierEvents[E]];
+};
+
+type NotifierEventListener = <E extends NotifierEventName>(
+  ...[event, ids]: NotifierEventsMap[E]
+) => void;
+
+export type NotifierEventParams = Parameters<NotifierEventListener>;
+
+type EventTypes = {
+  'notifier-event': NotifierEventListener;
+};
+
+const emitter = new EventEmitter<EventTypes>();
+
+export default class EventManager implements Service {
+  static readonly emit = emitter.emit.bind(emitter);
+  static readonly addListener = emitter.addListener.bind(emitter);
+
+  private observerID?: ReturnType<Zotero.Notifier['registerObserver']>;
+
+  public startup() {
+    this.registerObserver();
+
+    Zotero.getMainWindow().addEventListener('unload', this.unregisterObserver);
+  }
+
+  public shutdown() {
+    emitter.removeAllListeners();
+
+    this.unregisterObserver();
+
+    Zotero.getMainWindow().removeEventListener(
+      'unload',
+      this.unregisterObserver
+    );
+  }
+
+  private registerObserver = () => {
+    this.observerID = Zotero.Notifier.registerObserver(
+      this.observer,
+      ['collection', 'collection-item', 'item', 'item-tag'],
+      'notero'
+    );
+  };
+
+  private unregisterObserver = () => {
+    if (this.observerID) {
+      Zotero.Notifier.unregisterObserver(this.observerID);
+      delete this.observerID;
+    }
+  };
+
+  private observer = {
+    notify: (
+      event: string,
+      type: Zotero.Notifier.Type,
+      ids: NotifierIDs,
+      _extraData: Record<string, unknown>
+    ) => {
+      log(`Notified of ${event} ${type} for IDs ${JSON.stringify(ids)}`);
+
+      const eventName = `${type}.${event}`;
+
+      switch (eventName) {
+        case 'collection.delete':
+        case 'collection.modify':
+        case 'item.modify':
+          emitter.emit('notifier-event', eventName, ids as number[]);
+          break;
+        case 'collection-item.add':
+        case 'item-tag.modify':
+        case 'item-tag.remove':
+          emitter.emit('notifier-event', eventName, this.mapCompoundIDs(ids));
+          break;
+      }
+    },
+  };
+
+  private mapCompoundIDs(this: void, ids: NotifierIDs): [number, number][] {
+    return (ids as string[]).map((compoundID) => {
+      const ids = compoundID.split('-').map(Number);
+      return [ids[0], ids[1]];
+    });
+  }
+}

--- a/src/content/services/index.ts
+++ b/src/content/services/index.ts
@@ -1,4 +1,5 @@
 export type { Service } from './service';
 
+export { default as EventManager } from './event-manager';
 export { default as SyncManager } from './sync-manager';
 export { default as UIManager } from './ui-manager';

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -47,8 +47,7 @@ export default class SyncManager implements Service {
     Zotero.getMainWindow().addEventListener(
       'unload',
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      this.unregisterObserver,
-      false
+      this.unregisterObserver
     );
   }
 
@@ -58,8 +57,7 @@ export default class SyncManager implements Service {
     Zotero.getMainWindow().removeEventListener(
       'unload',
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      this.unregisterObserver,
-      false
+      this.unregisterObserver
     );
   }
 

--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -1,5 +1,5 @@
 import { IS_ZOTERO_7 } from '../constants';
-import { createXULElement, getLocalizedString } from '../utils';
+import { createXULElement, getLocalizedString, log } from '../utils';
 
 import type { Service } from './service';
 
@@ -15,26 +15,72 @@ export default class UIManager implements Service {
   private managedNodes = new Set<Node>();
 
   public startup() {
-    if (IS_ZOTERO_7) return;
-
-    const menuItem = createXULElement(this.document, 'menuitem');
-    menuItem.setAttribute(
-      'label',
-      getLocalizedString('notero.preferences.menuItem')
-    );
-    menuItem.addEventListener('command', () => {
-      this.openPreferences();
-    });
-    const toolsMenu = this.document.getElementById('menu_ToolsPopup');
-    if (toolsMenu) {
-      const toolsMenuItem = toolsMenu.appendChild(menuItem);
-      this.managedNodes.add(toolsMenuItem);
-    }
+    this.initCollectionMenuItem();
+    this.initItemMenuItem();
+    if (!IS_ZOTERO_7) this.initToolsMenuItem();
   }
 
   public shutdown() {
     this.managedNodes.forEach((node) => node.parentNode?.removeChild(node));
     this.managedNodes.clear();
+  }
+
+  private initCollectionMenuItem() {
+    this.createMenuItem({
+      labelName: 'notero.collectionMenu.sync',
+      parentId: 'zotero-collectionmenu',
+      onCommand: () => {
+        const collection =
+          Zotero.getActiveZoteroPane()?.getSelectedCollection(false);
+        log(JSON.stringify(collection));
+      },
+    });
+  }
+
+  private initItemMenuItem() {
+    this.createMenuItem({
+      labelName: 'notero.itemMenu.sync',
+      parentId: 'zotero-itemmenu',
+      onCommand: () => {
+        const items = Zotero.getActiveZoteroPane()?.getSelectedItems(false);
+        log(JSON.stringify(items));
+      },
+    });
+  }
+
+  private initToolsMenuItem() {
+    this.createMenuItem({
+      labelName: 'notero.toolsMenu.preferences',
+      parentId: 'menu_ToolsPopup',
+      onCommand: () => {
+        this.openPreferences();
+      },
+    });
+  }
+
+  private createMenuItem({
+    labelName,
+    onCommand,
+    parentId,
+  }: {
+    labelName: string;
+    onCommand: (event: Event) => void;
+    parentId: string;
+  }): XUL.MenuItemElement | null {
+    let menuItem = createXULElement(this.document, 'menuitem');
+    menuItem.setAttribute('label', getLocalizedString(labelName));
+    menuItem.addEventListener('command', onCommand);
+
+    const parentMenu = this.document.getElementById(parentId);
+    if (!parentMenu) {
+      log(`Failed to find element '${parentId}'`, 'error');
+      return null;
+    }
+
+    menuItem = parentMenu.appendChild(menuItem);
+    this.managedNodes.add(menuItem);
+
+    return menuItem;
   }
 
   private openPreferences() {

--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -1,6 +1,7 @@
 import { IS_ZOTERO_7 } from '../constants';
 import { createXULElement, getLocalizedString, log } from '../utils';
 
+import EventManager from './event-manager';
 import type { Service } from './service';
 
 export default class UIManager implements Service {
@@ -32,7 +33,9 @@ export default class UIManager implements Service {
       onCommand: () => {
         const collection =
           Zotero.getActiveZoteroPane()?.getSelectedCollection(false);
-        log(JSON.stringify(collection));
+        if (collection) {
+          EventManager.emit('request-sync-collection', collection);
+        }
       },
     });
   }
@@ -43,7 +46,9 @@ export default class UIManager implements Service {
       parentId: 'zotero-itemmenu',
       onCommand: () => {
         const items = Zotero.getActiveZoteroPane()?.getSelectedItems(false);
-        log(JSON.stringify(items));
+        if (items) {
+          EventManager.emit('request-sync-items', items);
+        }
       },
     });
   }

--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -1,3 +1,4 @@
+import { IS_ZOTERO_7 } from '../constants';
 import { createXULElement, getLocalizedString } from '../utils';
 
 import type { Service } from './service';
@@ -14,6 +15,8 @@ export default class UIManager implements Service {
   private managedNodes = new Set<Node>();
 
   public startup() {
+    if (IS_ZOTERO_7) return;
+
     const menuItem = createXULElement(this.document, 'menuitem');
     menuItem.setAttribute(
       'label',

--- a/src/locale/en-US/notero.properties
+++ b/src/locale/en-US/notero.properties
@@ -1,4 +1,9 @@
-notero.preferences.menuItem         = Notero Preferences...
+notero.collectionMenu.sync = Sync Items to Notion
+
+notero.itemMenu.sync = Sync to Notion
+
+notero.toolsMenu.preferences = Notero Preferences...
+
 notero.preferences.notionToken      = Notion Integration Token
 notero.preferences.notionDatabaseID = Notion Database ID
 

--- a/src/locale/zh-CN/notero.properties
+++ b/src/locale/zh-CN/notero.properties
@@ -1,4 +1,9 @@
-notero.preferences.menuItem         = Notero 首选项...
+notero.collectionMenu.sync = Sync Items to Notion
+
+notero.itemMenu.sync = Sync to Notion
+
+notero.toolsMenu.preferences = Notero 首选项...
+
 notero.preferences.notionToken      = Notion 内部集成令牌
 notero.preferences.notionDatabaseID = Notion 数据库 ID
 

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -359,6 +359,15 @@ declare namespace Zotero {
 
   interface ZoteroPane {
     document: Document;
+
+    getSelectedCollection<A extends boolean>(
+      asID: A
+    ): (A extends true ? number : Collection) | undefined;
+
+    getSelectedItems<A extends boolean>(
+      asIDs: A
+    ): A extends true ? number[] : Item[];
+
     loadURI(uris: string | string[]): void;
   }
 }


### PR DESCRIPTION
Add a "Sync to Notion" menu item to both the collection context menu and item context menu. When the collection menu item is selected, all items in the collection are synced. When the item menu item is selected, all selected items are synced.

## Known issues

- The menu item appears for all entries in the left sidebar, including those that are _not_ collections. This presents a confusing experience since selecting the menu item ends up doing nothing for entries that are not collections.