### PR TITLE
fix: Sync top-level items from context menu

### DIFF
--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -47,7 +47,8 @@ export default class UIManager implements Service {
       onCommand: () => {
         const items = Zotero.getActiveZoteroPane()?.getSelectedItems(false);
         if (items) {
-          EventManager.emit('request-sync-items', items);
+          const topLevelItems = Zotero.Items.getTopLevel(items);
+          EventManager.emit('request-sync-items', topLevelItems);
         }
       },
     });

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -170,7 +170,10 @@ declare namespace Zotero {
     setNote(text: string): boolean;
   }
 
-  type Items = DataObjects<Item>;
+  interface Items extends DataObjects<Item> {
+    /** Get the top-level items of all passed items */
+    getTopLevel(items: Item[]): Item[];
+  }
 
   interface ItemTypes {
     getLocalizedString(idOrName: number | string): string;


### PR DESCRIPTION
When selecting an item or items to sync from the context menu, ensure that only top-level items are requested to sync.