### PR TITLE
build: Update patch for `node-fetch` package

### DIFF
--- a/patches/node-fetch+2.6.9.patch
+++ b/patches/node-fetch+2.6.9.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/node-fetch/browser.js b/node_modules/node-fetch/browser.js
-index 83c54c5..e60b420 100644
+index ee86265..6d9f34f 100644
 --- a/node_modules/node-fetch/browser.js
 +++ b/node_modules/node-fetch/browser.js
 @@ -5,6 +5,7 @@ var getGlobal = function () {


### PR DESCRIPTION
I forgot to run `npx patch-package node-fetch` after `node-fetch` was updated in #247.