### PR TITLE
refactor: Add types for `Zotero.Date`

### DIFF
--- a/src/content/notion.ts
+++ b/src/content/notion.ts
@@ -79,7 +79,6 @@ export default class Notion {
     return date && { start: date.toISOString() };
   }
 
-
   static convertWebURLToAppURL(url: string): string {
     return url.replace(/^https:/, this.APP_URL_PROTOCOL);
   }

--- a/typings/zotero.d.ts
+++ b/typings/zotero.d.ts
@@ -132,6 +132,15 @@ declare namespace Zotero {
     getLoaded(): T[];
   }
 
+  interface Date {
+    /**
+     * Convert an SQL date in the form '2006-06-13 11:03:05' into a JS Date object
+     *
+     * Can also accept just the date part (e.g. '2006-06-13')
+     */
+    sqlToDate(sqldate: string, isUTC?: boolean): globalThis.Date | false;
+  }
+
   interface Item extends DataObject {
     readonly itemTypeID: number;
     readonly itemType: string;
@@ -432,6 +441,7 @@ declare interface Zotero {
   Attachments: Zotero.Attachments;
   Collections: Zotero.Collections;
   CreatorTypes: Zotero.CreatorTypes;
+  Date: Zotero.Date;
   Items: Zotero.Items;
   ItemTypes: Zotero.ItemTypes;
   Notifier: Zotero.Notifier;


### PR DESCRIPTION
Add TypeScript type definitions for `Zotero.Date` based on https://github.com/zotero/utilities/blob/9e71e449b67e7e4a437f77d234613587b7c5d4c7/date.js