### PR TITLE
feat: Localize Zotero 7 preference pane using Fluent

### DIFF
--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -1,17 +1,21 @@
+<linkset>
+  <html:link rel="localization" href="notero.ftl" />
+</linkset>
+
+<!-- The `notero` variable used below is defined in `esbuild.js` -->
 <vbox onload="notero.preferences.init();">
   <vbox class="main-section">
-    <html:h1>&notero.preferences.notionGroupboxCaption;</html:h1>
-    <description>
-      &notero.preferences.notionGroupboxDescription;
+    <html:h1 data-l10n-id="notero-preferences-notion-groupbox-heading" />
+    <description data-l10n-id="notero-preferences-notion-groupbox-description">
       <label
+        data-l10n-name="notero-preferences-readme"
         is="zotero-text-link"
         href="https://github.com/dvanoni/notero#readme"
-        value="&notero.preferences.readme;"
-      />.
+      />
     </description>
     <groupbox>
       <label control="notero-notionToken">
-        <html:h2>&notero.preferences.notionToken;</html:h2>
+        <html:h2 data-l10n-id="notero-preferences-notion-token" />
       </label>
       <html:input
         id="notero-notionToken"
@@ -19,7 +23,7 @@
         type="text"
       />
       <label control="notero-notionDatabaseID">
-        <html:h2>&notero.preferences.notionDatabaseID;</html:h2>
+        <html:h2 data-l10n-id="notero-preferences-notion-database-id" />
       </label>
       <html:input
         id="notero-notionDatabaseID"
@@ -30,13 +34,13 @@
   </vbox>
 
   <vbox class="main-section">
-    <html:h1>&notero.preferences.propertiesGroupboxCaption;</html:h1>
-    <description>
-      &notero.preferences.propertiesGroupboxDescription;
-    </description>
+    <html:h1 data-l10n-id="notero-preferences-properties-groupbox-heading" />
+    <description
+      data-l10n-id="notero-preferences-properties-groupbox-description"
+    />
     <groupbox>
       <label control="notero-pageTitleFormat">
-        <html:h2>&notero.preferences.pageTitleFormat;</html:h2>
+        <html:h2 data-l10n-id="notero-preferences-page-title-format" />
       </label>
       <menulist
         id="notero-pageTitleFormat"
@@ -48,19 +52,25 @@
   </vbox>
 
   <vbox class="main-section">
-    <html:h1>&notero.preferences.syncGroupboxCaption;</html:h1>
-    <description>&notero.preferences.syncGroupboxDescription1;</description>
-    <description>&notero.preferences.syncGroupboxDescription2;</description>
+    <html:h1 data-l10n-id="notero-preferences-sync-groupbox-heading" />
+    <description data-l10n-id="notero-preferences-sync-groupbox-description1" />
+    <description data-l10n-id="notero-preferences-sync-groupbox-description2" />
     <separator class="thin" />
     <hbox class="virtualized-table-container" flex="1" height="220px">
       <html:div id="notero-syncConfigsTable-container" />
     </hbox>
     <separator class="thin" />
     <checkbox
+      data-l10n-id="notero-preferences-sync-on-modify-items"
       id="notero-syncOnModifyItems"
-      label="&notero.preferences.syncOnModifyItems;"
       native="true"
       preference="extensions.notero.syncOnModifyItems"
+    />
+    <checkbox
+      data-l10n-id="notero-preferences-sync-notes"
+      id="notero-syncNotes"
+      native="true"
+      preference="extensions.notero.syncNotes"
     />
   </vbox>
 </vbox>

--- a/src/content/services/preference-pane-manager.ts
+++ b/src/content/services/preference-pane-manager.ts
@@ -7,7 +7,6 @@ export class PreferencePaneManager implements Service {
       src: rootURI + 'content/prefs/preferences.xhtml',
       scripts: [rootURI + 'content/prefs/preferences.js'],
       stylesheets: [rootURI + 'content/style/preferences.css'],
-      extraDTD: ['chrome://notero/locale/notero.dtd'],
       helpURL: 'https://github.com/dvanoni/notero#readme',
     });
   }

--- a/src/locale/en-US/notero.ftl
+++ b/src/locale/en-US/notero.ftl
@@ -1,0 +1,36 @@
+## Notion preferences
+
+notero-preferences-notion-groupbox-heading = Notion Preferences
+notero-preferences-notion-groupbox-description =
+  For instructions on obtaining these values, view the
+  <label data-l10n-name="notero-preferences-readme">README</label>.
+
+notero-preferences-notion-token = Integration Token
+notero-preferences-notion-database-id = Database ID
+
+## Property preferences
+
+notero-preferences-properties-groupbox-heading = Property Preferences
+notero-preferences-properties-groupbox-description =
+  Customize how item properties sync to Notion.
+
+notero-preferences-page-title-format = Notion Page Title
+
+## Sync preferences
+
+notero-preferences-sync-groupbox-heading = Sync Preferences
+notero-preferences-sync-groupbox-description1 =
+  Notero will monitor the collections enabled below.
+  Items in the enabled collections will sync to Notion when added
+  to that collection and whenever the items are modified.
+notero-preferences-sync-groupbox-description2 =
+  To enable/disable a collection, either select the row and press the
+  {"[Enter]"} key or double-click the row. To select multiple rows,
+  hold {"[Shift]"} and then click.
+
+notero-preferences-collection-column = Collection
+notero-preferences-sync-enabled-column = Sync Enabled
+notero-preferences-sync-on-modify-items =
+  .label = Sync when items are modified
+notero-preferences-sync-notes =
+  .label = Sync notes (EXPERIMENTAL)

--- a/src/locale/zh-CN/notero.dtd
+++ b/src/locale/zh-CN/notero.dtd
@@ -20,4 +20,4 @@
 <!ENTITY notero.preferences.collectionColumn "集合">
 <!ENTITY notero.preferences.syncEnabledColumn "启用同步">
 <!ENTITY notero.preferences.syncOnModifyItems "当修改条目时同步">
-<!ENTITY notero.preferences.syncNotes "Sync notes (EXPERIMENTAL)">
+<!ENTITY notero.preferences.syncNotes "同步笔记（实验）">

--- a/src/locale/zh-CN/notero.ftl
+++ b/src/locale/zh-CN/notero.ftl
@@ -31,4 +31,4 @@ notero-preferences-sync-enabled-column = 启用同步
 notero-preferences-sync-on-modify-items =
   .label = 当修改条目时同步
 notero-preferences-sync-notes =
-  .label = Sync notes (EXPERIMENTAL)
+  .label = 同步笔记（实验）

--- a/src/locale/zh-CN/notero.ftl
+++ b/src/locale/zh-CN/notero.ftl
@@ -1,0 +1,34 @@
+## Notion preferences
+
+notero-preferences-notion-groupbox-heading = Notion 首选项
+notero-preferences-notion-groupbox-description =
+  有关获取这些值的说明，请查看
+  <label data-l10n-name="notero-preferences-readme">README</label>.
+
+notero-preferences-notion-token = 内部集成令牌
+notero-preferences-notion-database-id = 数据库 ID
+
+## Property preferences
+
+notero-preferences-properties-groupbox-heading = 属性偏好
+notero-preferences-properties-groupbox-description =
+  自定义项目属性如何同步到 Notion。
+
+notero-preferences-page-title-format = 概念页面标题
+
+## Sync preferences
+
+notero-preferences-sync-groupbox-heading = 同步首选项
+notero-preferences-sync-groupbox-description1 =
+  Notero 将监控下面启用的集合。
+  将条目添加到该启用的集合中以及当条目被修改时，都将同步到 Notion。
+notero-preferences-sync-groupbox-description2 =
+  要启用/禁用集合，请选择该行并按 {"[Enter]"} 键或双击该行。
+  要选择多行，请按住 {"[Shift]"} 然后单击。
+
+notero-preferences-collection-column = 集合
+notero-preferences-sync-enabled-column = 启用同步
+notero-preferences-sync-on-modify-items =
+  .label = 当修改条目时同步
+notero-preferences-sync-notes =
+  .label = Sync notes (EXPERIMENTAL)


### PR DESCRIPTION
Use [Fluent](https://projectfluent.org/) for localization in the Zotero 7 preference pane since [DTD support was removed](https://groups.google.com/g/zotero-dev/c/M_86IbuT8Nc).

Also localize the "sync notes" preference in Chinese since that wasn't included in #290.