### PR TITLE
feat: Enable support for Zotero 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "xpi": {
     "name": "Notero",
     "bootstrapped": true,
-    "releaseURL": "https://github.com/dvanoni/notero/releases/download/release/"
+    "releaseURL": "https://github.com/dvanoni/notero/releases/download/release/",
+    "supportsZotero7": true
   }
 }


### PR DESCRIPTION
Enable the `xpi.supportsZotero7` property used by [zotero-plugin](https://github.com/dvanoni/zotero-plugin/blob/f4f6b7080ebe2979933b645c16e162a1f44141d5/bin/generate-update-manifest.ts#L42) to indicate support for Zotero 7 in `update.rdf`/`update.json`.