### PR TITLE
refactor: Enable stricter type checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/strict-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'prettier',
@@ -26,6 +26,10 @@ module.exports = {
     },
   },
   rules: {
+    '@typescript-eslint/no-invalid-void-type': [
+      'error',
+      { allowAsThisParameter: true },
+    ],
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -3,7 +3,7 @@ import type { Notero } from './content/notero';
 const LOG_PREFIX = 'Notero: ';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error
 if (typeof Zotero === 'undefined') {
   // eslint-disable-next-line no-var
   var Zotero: Zotero & { Notero?: Notero };
@@ -23,7 +23,8 @@ function log(msg: string) {
 // and the `Zotero` is automatically made available.
 async function waitForZotero() {
   if (typeof Zotero !== 'undefined') {
-    return await Zotero.initializationPromise;
+    await Zotero.initializationPromise;
+    return;
   }
 
   const { Services } = ChromeUtils.import(
@@ -104,7 +105,7 @@ async function startup(
 
   // `Services` may not be available in Zotero 6
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   if (typeof Services === 'undefined') {
     // eslint-disable-next-line no-var
     var { Services } = ChromeUtils.import(

--- a/src/content/notero-item.ts
+++ b/src/content/notero-item.ts
@@ -123,7 +123,7 @@ export class NoteroItem {
         inTextCitation,
       );
     }
-    return this.cachedCitations[cacheKey];
+    return this.cachedCitations[cacheKey] || null;
   }
 
   public async getAuthorDateCitation(): Promise<string | null> {

--- a/src/content/prefs/sync-configs-table.tsx
+++ b/src/content/prefs/sync-configs-table.tsx
@@ -99,10 +99,12 @@ export class SyncConfigsTable extends React.Component {
   }
 
   private toggleEnabled(indices: number[]) {
-    const enable = !indices.every((index) => this.rows[index].syncEnabled);
+    const enable = !indices.every((index) => this.rows[index]?.syncEnabled);
 
     this.syncConfigs = indices.reduce((configs, index) => {
-      const { collection } = this.rows[index];
+      const collection = this.rows[index]?.collection;
+      if (!collection) return configs;
+
       return {
         ...configs,
         [collection.id]: {
@@ -114,7 +116,7 @@ export class SyncConfigsTable extends React.Component {
 
   getRowCount = () => this.rows.length;
 
-  getRowString = (index: number) => this.rows[index].collectionFullName;
+  getRowString = (index: number) => this.rows[index]?.collectionFullName || '';
 
   handleActivate = (_event: KeyboardEvent | MouseEvent, indices: number[]) => {
     this.toggleEnabled(indices);
@@ -124,12 +126,12 @@ export class SyncConfigsTable extends React.Component {
 
   handleColumnSort = (columnIndex: number, sortDirection: number) => {
     this.sortDirection = sortDirection;
-    this.sortKey = COLUMNS[columnIndex]['dataKey'];
+    this.sortKey = COLUMNS[columnIndex]?.['dataKey'] || 'collectionFullName';
     this.invalidateRows();
     this.table?.invalidate();
   };
 
-  renderItem = makeRowRenderer((index) => this.rows[index]);
+  renderItem = makeRowRenderer((index) => this.rows[index] || {});
 
   render() {
     return (

--- a/src/content/services/chrome-manager.ts
+++ b/src/content/services/chrome-manager.ts
@@ -4,9 +4,10 @@ export class ChromeManager implements Service {
   private chromeHandle?: XPCOM.nsIJSRAIIHelper;
 
   public startup({ rootURI }: PluginInfo) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const aomStartup = Cc[
       '@mozilla.org/addons/addon-manager-startup;1'
-    ].getService(Ci.amIAddonManagerStartup);
+    ]!.getService(Ci.amIAddonManagerStartup);
 
     const manifestURI = Services.io.newURI(rootURI + 'manifest.json');
 

--- a/src/content/services/event-manager.ts
+++ b/src/content/services/event-manager.ts
@@ -106,7 +106,7 @@ export class EventManager implements Service {
 
   private mapCompoundIDs(this: void, ids: NotifierIDs): [number, number][] {
     return (ids as string[]).map((compoundID) => {
-      const ids = compoundID.split('-').map(Number);
+      const ids = compoundID.split('-').map(Number) as [number, number];
       return [ids[0], ids[1]];
     });
   }

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -133,7 +133,7 @@ export class SyncManager implements Service {
    * @param ids An array of compound IDs.
    * @returns An array of extracted IDs.
    */
-  private getIndexedIDs(this: void, index: number, ids: number[][]) {
+  private getIndexedIDs(this: void, index: 0 | 1, ids: [number, number][]) {
     return ids.map((compoundID) => compoundID[index]);
   }
 
@@ -228,7 +228,7 @@ export class SyncManager implements Service {
     }
 
     const itemIDs = new Set([
-      ...(this.queuedSync?.itemIDs?.values() ?? []),
+      ...(this.queuedSync?.itemIDs.values() ?? []),
       ...idsToSync,
     ]);
 

--- a/src/content/sync/html-to-notion/html-to-notion.ts
+++ b/src/content/sync/html-to-notion/html-to-notion.ts
@@ -305,6 +305,8 @@ function trimRichText(richText: RichText): RichText {
   ): RichText {
     const richTextPart = richText[index];
 
+    if (!richTextPart) return [];
+
     if (!('text' in richTextPart)) return [richTextPart];
 
     const content = updater(richTextPart.text.content);

--- a/src/content/sync/sync-note.ts
+++ b/src/content/sync/sync-note.ts
@@ -66,6 +66,8 @@ async function createContainerBlock(
     ],
   });
 
+  if (!results[0]) throw new Error('Failed to create container block');
+
   return results[0].id;
 }
 
@@ -85,6 +87,8 @@ async function createNoteBlock(
       },
     ],
   });
+
+  if (!results[0]) throw new Error('Failed to create note block');
 
   const noteBlockID = results[0].id;
 

--- a/src/content/utils/getDOMParser.ts
+++ b/src/content/utils/getDOMParser.ts
@@ -2,7 +2,8 @@ export function getDOMParser() {
   try {
     return new DOMParser();
   } catch {
-    return Cc['@mozilla.org/xmlextras/domparser;1'].createInstance(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return Cc['@mozilla.org/xmlextras/domparser;1']!.createInstance(
       Ci.nsIDOMParser,
     );
   }

--- a/src/content/utils/getLocalizedString.ts
+++ b/src/content/utils/getLocalizedString.ts
@@ -6,7 +6,7 @@ Components.utils.import('resource://gre/modules/Services.jsm');
 
 const STRING_BUNDLE_URL = 'chrome://notero/locale/notero.properties';
 
-let stringBundle: XPCOM.nsIStringBundle;
+let stringBundle: XPCOM.nsIStringBundle | undefined;
 
 function getStringBundle(): XPCOM.nsIStringBundle {
   if (!stringBundle) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react",
     "lib": ["es2017", "dom"],
     "module": "commonjs",
+    "noUncheckedIndexedAccess": true,
     "preserveConstEnums": false,
     "removeComments": false,
     "sourceMap": true,

--- a/types/components/virtualized-table.d.ts
+++ b/types/components/virtualized-table.d.ts
@@ -154,5 +154,6 @@ declare module 'components/virtualized-table' {
   // eslint-disable-next-line import/no-default-export
   export default VirtualizedTable;
 
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
   class WindowedList {}
 }


### PR DESCRIPTION
Enable the `strict-type-checked` ESLint rules [provided by v6 of `typescript-eslint`](https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/#reworked-configuration-names).

Also enable the [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) option in `tsconfig.json` so that indexing arrays or objects will include `undefined` in the type.