### PR TITLE
feat: Support note highlight colors other than Zotero's

### DIFF
--- a/src/content/sync/html-to-notion/__tests__/annotations.spec.ts
+++ b/src/content/sync/html-to-notion/__tests__/annotations.spec.ts
@@ -1,0 +1,114 @@
+import type { Color } from '../../notion-types';
+import { getNotionColor } from '../annotations';
+
+type Hex = `#${string}`;
+
+type ColorProperties = {
+  backgroundColor?: Hex;
+  color?: Hex;
+};
+
+type ColorTestCase = [hex: Hex, expected: NonNullable<Color>];
+
+// From https://www.zotero.org/support/note_templates#variables
+const zoteroBackgroundColors: ColorTestCase[] = [
+  ['#ff6666', 'red_background'],
+  ['#f19837', 'orange_background'],
+  ['#ffd400', 'yellow_background'],
+  ['#5fb236', 'green_background'],
+  ['#2ea8e5', 'blue_background'],
+  ['#a28ae5', 'purple_background'],
+  ['#e56eee', 'pink_background'],
+  ['#aaaaaa', 'gray_background'],
+];
+
+// Determined empirically from Zotero
+const zoteroTextColors: ColorTestCase[] = [
+  ['#ff2020', 'red'],
+  ['#ff7700', 'orange'],
+  ['#ffcb00', 'yellow'],
+  ['#4eb31c', 'green'],
+  ['#05a2ef', 'blue'],
+  ['#7953e3', 'purple'],
+  ['#eb52f7', 'pink'],
+  ['#7e8386', 'gray'],
+];
+
+const customBackgroundColors: ColorTestCase[] = [
+  // A gray that's not completely achromatic
+  ['#ddddd9', 'gray_background'],
+  // Based on a PDF shared in https://github.com/dvanoni/notero/issues/4#issuecomment-1661322835
+  ['#ffcd99', 'orange_background'],
+  ['#ffff55', 'yellow_background'],
+  ['#55ff55', 'green_background'],
+  ['#acfff3', 'blue_background'],
+];
+
+function buildElement({ backgroundColor, color }: ColorProperties) {
+  const element = document.createElement('p');
+
+  if (backgroundColor) {
+    element.style.backgroundColor = backgroundColor;
+  }
+
+  if (color) {
+    element.style.color = color;
+  }
+
+  return element;
+}
+
+describe('getNotionColor', () => {
+  it('returns undefined when element has no colors', () => {
+    const element = buildElement({});
+    expect(getNotionColor(element)).toBeUndefined();
+  });
+
+  it('returns `green` when color is Zotero green', () => {
+    const element = buildElement({ color: '#4eb31c' });
+    const expected: Color = 'green';
+    expect(getNotionColor(element)).toBe(expected);
+  });
+
+  it('returns `green_background` when backgroundColor is Zotero green', () => {
+    const element = buildElement({ backgroundColor: '#5fb236' });
+    const expected: Color = 'green_background';
+    expect(getNotionColor(element)).toBe(expected);
+  });
+
+  it('returns `green_background` when both color and backgroundColor are Zotero green', () => {
+    const element = buildElement({
+      backgroundColor: '#5fb236',
+      color: '#4eb31c',
+    });
+    const expected: Color = 'green_background';
+    expect(getNotionColor(element)).toBe(expected);
+  });
+
+  it('returns `green_background` when backgroundColor is custom green', () => {
+    const element = buildElement({ backgroundColor: '#55ff55' });
+    const expected: Color = 'green_background';
+    expect(getNotionColor(element)).toBe(expected);
+  });
+
+  describe('with Zotero background color', () => {
+    it.each(zoteroBackgroundColors)('%s returns %s', (hex, expected) => {
+      const element = buildElement({ backgroundColor: hex });
+      expect(getNotionColor(element)).toBe(expected);
+    });
+  });
+
+  describe('with Zotero text color', () => {
+    it.each(zoteroTextColors)('%s returns %s', (hex, expected) => {
+      const element = buildElement({ color: hex });
+      expect(getNotionColor(element)).toBe(expected);
+    });
+  });
+
+  describe('with custom background color', () => {
+    it.each(customBackgroundColors)('%s returns %s', (hex, expected) => {
+      const element = buildElement({ backgroundColor: hex });
+      expect(getNotionColor(element)).toBe(expected);
+    });
+  });
+});

--- a/src/content/sync/html-to-notion/__tests__/fixtures/annotations.html
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/annotations.html
@@ -1,0 +1,51 @@
+<div data-schema-version="9">
+  <blockquote>
+    <p>
+      <span class="highlight"
+        ><span style="background-color: #ffff5580">Yellow</span></span
+      >
+    </p>
+  </blockquote>
+  <p>
+    <span class="citation"
+      >(<span class="citation-item">Author, p. 2</span>)</span
+    >
+  </p>
+  <blockquote>
+    <p>
+      <span class="highlight"
+        ><span style="background-color: #ffed9980">Orange</span></span
+      >
+    </p>
+  </blockquote>
+  <p>
+    <span class="citation"
+      >(<span class="citation-item">Author, p. 3</span>)</span
+    >
+  </p>
+  <blockquote>
+    <p>
+      <span class="highlight"
+        ><span style="background-color: #55ff5580">Green</span></span
+      >
+    </p>
+  </blockquote>
+  <p>
+    <span class="citation"
+      >(<span class="citation-item">Author, p. 4</span>)</span
+    >
+    Custom note
+  </p>
+  <blockquote>
+    <p>
+      <span class="highlight"
+        ><span style="background-color: #acfff380">Blue</span></span
+      >
+    </p>
+  </blockquote>
+  <p>
+    <span class="citation"
+      >(<span class="citation-item">Author, p. 5</span>)</span
+    >
+  </p>
+</div>

--- a/src/content/sync/html-to-notion/__tests__/fixtures/annotations.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/annotations.ts
@@ -1,0 +1,82 @@
+import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+
+// Based on a PDF shared in https://github.com/dvanoni/notero/issues/4#issuecomment-1661322835
+export const expected: BlockObjectRequest[] = [
+  {
+    quote: {
+      rich_text: [
+        {
+          text: { content: 'Yellow' },
+          annotations: { color: 'yellow_background' },
+        },
+      ],
+    },
+  },
+  {
+    paragraph: {
+      rich_text: [
+        { text: { content: '(' } },
+        { text: { content: 'Author, p. 2' } },
+        { text: { content: ')' } },
+      ],
+    },
+  },
+  {
+    quote: {
+      rich_text: [
+        {
+          text: { content: 'Orange' },
+          annotations: { color: 'orange_background' },
+        },
+      ],
+    },
+  },
+  {
+    paragraph: {
+      rich_text: [
+        { text: { content: '(' } },
+        { text: { content: 'Author, p. 3' } },
+        { text: { content: ')' } },
+      ],
+    },
+  },
+  {
+    quote: {
+      rich_text: [
+        {
+          text: { content: 'Green' },
+          annotations: { color: 'green_background' },
+        },
+      ],
+    },
+  },
+  {
+    paragraph: {
+      rich_text: [
+        { text: { content: '(' } },
+        { text: { content: 'Author, p. 4' } },
+        { text: { content: ')' } },
+        { text: { content: ' Custom note' } },
+      ],
+    },
+  },
+  {
+    quote: {
+      rich_text: [
+        {
+          text: { content: 'Blue' },
+          annotations: { color: 'blue_background' },
+        },
+      ],
+    },
+  },
+  {
+    paragraph: {
+      rich_text: [
+        { text: { content: '(' } },
+        { text: { content: 'Author, p. 5' } },
+        { text: { content: ')' } },
+      ],
+    },
+  },
+];

--- a/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
+import * as annotations from './annotations';
 import * as blockquote from './blockquote';
 import * as formatting from './formatting';
 import * as nestedStyles from './nestedStyles';
@@ -18,6 +19,7 @@ const cases: Record<string, Pick<NoteTestCase, 'expected'>> = {
   simple,
   blockquote,
   nestedStyles,
+  annotations,
   formatting,
 };
 


### PR DESCRIPTION
Syncing Zotero notes previously only supported highlight colors that were exactly those used in Zotero. As mentioned in https://github.com/dvanoni/notero/issues/4#issuecomment-1661322835, this meant that highlights from applications other than Zotero would most likely use different colors and thus not sync correctly into Notion.

This PR updates the color detection so that, instead of looking for an exact match with Zotero colors, the closest matching color is used. The color matching uses the ["redmean"](https://en.wikipedia.org/wiki/Color_difference) approach to best approximate a perceptually-closest color.