### PR TITLE
fix: Downgrade `core-js` to v3.31.1 to fix issue with `use strict`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@notionhq/client": "^2.2.9",
-        "core-js": "^3.32.0",
+        "core-js": "^3.31.1",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
@@ -3901,9 +3901,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.1.tgz",
+      "integrity": "sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/dvanoni/notero",
   "dependencies": {
     "@notionhq/client": "^2.2.9",
-    "core-js": "^3.32.0",
+    "core-js": "^3.31.1",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #314, fixes #315

# Problem

As reported in #314 and #315, the release of [v0.4.10](https://github.com/dvanoni/notero/releases/tag/v0.4.10) broke Notero for users on Zotero 6 such that it was no longer usable at all.

## Error details

Investigating the issue uncovered the offending error:

> global2[CONSTRUCTOR] is undefined

with partial stack trace:

> node_modules/core-js/internals/entry-unbind.js/module.exports -> /build/content/notero.js:3489:9
> node_modules/core-js/es/string/trim-end.js -> /build/content/notero.js:3500:24
> __require -> /build/content/notero.js:20:20

## Code change

<details>
<summary>The relevant code from the bundled <code>notero.js</code> in v0.4.10 is as follows:</summary>

```js
// node_modules/core-js/internals/global.js
var require_global = __commonJS({
  "node_modules/core-js/internals/global.js"(exports, module) {
    "use strict";
    var check = function(it) {
      return it && it.Math == Math && it;
    };
    module.exports = // eslint-disable-next-line es/no-global-this -- safe
    check(typeof globalThis == "object" && globalThis) || check(typeof window == "object" && window) || // eslint-disable-next-line no-restricted-globals -- safe
    check(typeof self == "object" && self) || check(typeof global == "object" && global) || // eslint-disable-next-line no-new-func -- fallback
    function() {
      return this;
    }() || exports || Function("return this")();
  }
});

// node_modules/core-js/internals/entry-unbind.js
var require_entry_unbind = __commonJS({
  "node_modules/core-js/internals/entry-unbind.js"(exports, module) {
    "use strict";
    var global2 = require_global();
    var uncurryThis = require_function_uncurry_this();
    module.exports = function(CONSTRUCTOR, METHOD) {
      return uncurryThis(global2[CONSTRUCTOR].prototype[METHOD]);
    };
  }
});

// node_modules/core-js/es/string/trim-end.js
var require_trim_end = __commonJS({
  "node_modules/core-js/es/string/trim-end.js"(exports, module) {
    "use strict";
    require_es_string_trim_end();
    var entryUnbind = require_entry_unbind();
    module.exports = entryUnbind("String", "trimRight");
  }
});
```
</details>

So as best I can tell, we're failing to find `String` on the global object, but I haven't determined why this is.

After building with different versions of `core-js`, I determined that the change that's causing this issue is the introduction of strict mode (`use strict`) in https://github.com/zloirock/core-js/commit/11f4ec8bb27f0f5513b6c61a68b8623c64f5a1b2. This change was included in `core-js` [v3.32.0](https://github.com/zloirock/core-js/releases/tag/v3.32.0) which we upgraded to in #307 (included in Notero v0.4.10).

# Solution

The immediate (and hopefully temporary) solution is to downgrade `core-js` to the previous version (v.3.31.1) so that `use strict` is not included.

After releasing this fix, I'll continue investigating to determine the actual cause and hopefully find a proper fix.