### PR TITLE
refactor: Improve usage of `@ts-expect-error`

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -2,8 +2,7 @@ import type { Notero } from './content/notero';
 
 const LOG_PREFIX = 'Notero: ';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
+// @ts-expect-error Check if `Zotero` is defined
 if (typeof Zotero === 'undefined') {
   // eslint-disable-next-line no-var
   var Zotero: Zotero & { Notero?: Notero };
@@ -104,8 +103,7 @@ async function startup(
   log('Starting');
 
   // `Services` may not be available in Zotero 6
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-expect-error
+  // @ts-expect-error Check if `Services` is defined
   if (typeof Services === 'undefined') {
     // eslint-disable-next-line no-var
     var { Services } = ChromeUtils.import(


### PR DESCRIPTION
The default value for the [@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment/) rule sets `ts-expect-error` to `allow-with-description`, meaning that `@ts-expect-error` comments are allowed if they have a description following the directive.

So, this PR adds descriptions to the two `@ts-expect-error` comments in the code base, enabling us to remove a couple `eslint-disable-next-line` comments. ⭐ 