### PR TITLE
build(dependabot): Group dev dependency upgrades together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Use the Dependabot [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) configuration option to group together minor and patch version upgrades for development dependencies.