### PR TITLE
build(dependabot): Exclude esbuild from dev-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: 'development'
+        exclude-patterns:
+          - 'esbuild'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
Exclude `esbuild` from the Dependabot `dev-dependencies` group because it's on pre-1.0 versions—meaning a **minor** version bump is actually a **major** version bump.