### PR TITLE
build(dependabot): Group dependency updates for related major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,12 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      commitlint:
+        patterns:
+          - '@commitlint*'
+      jest:
+        patterns:
+          - '*jest*'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint*'


### PR DESCRIPTION
With the current `groups` configuration, **minor/patch** version updates for dev dependencies are all included together in the `dev-dependencies` group, but **major** versions are not. Each dependency instead receives its own separate PR even if multiple updates should be included together—e.g. #358 and #360.

To prevent this issue, this PR creates groups for `commitlint`, `jest`, and `typescript-eslint`. It relies on the following property described in the [`groups` configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) docs:

> Dependabot creates groups in the order they appear in your `dependabot.yml` file. If a dependency update could belong to more than one group, it is only assigned to the first group it matches with.
