### PR TITLE
fix: Batch note block requests to comply with Notion API limits

### DIFF
--- a/src/content/sync/notion-limits.ts
+++ b/src/content/sync/notion-limits.ts
@@ -1,0 +1,15 @@
+/**
+ * @see https://developers.notion.com/reference/request-limits#limits-for-property-values
+ */
+export const LIMITS = {
+  TEXT_CONTENT_CHARACTERS: 2000,
+  TEXT_LINK_URL_CHARACTERS: 2000,
+  EQUATION_EXPRESSION_CHARACTERS: 1000,
+  BLOCK_ARRAY_ELEMENTS: 100,
+  URL_CHARACTERS: 2000,
+  EMAIL_CHARACTERS: 200,
+  PHONE_NUMBER_CHARACTERS: 200,
+  MULTI_SELECT_OPTIONS: 100,
+  RELATION_RELATED_PAGES: 100,
+  PEOPLE_USERS: 100,
+} as const;

--- a/src/content/sync/notion-utils/build-rich-text.ts
+++ b/src/content/sync/notion-utils/build-rich-text.ts
@@ -1,8 +1,6 @@
 import { chunkString } from '../../utils';
+import { LIMITS } from '../notion-limits';
 import type { RichText, RichTextOptions, RichTextText } from '../notion-types';
-
-// https://developers.notion.com/reference/request-limits#limits-for-property-values
-const TEXT_CONTENT_MAX_LENGTH = 2000;
 
 export function buildRichText(
   textContent: string | null | undefined,
@@ -18,7 +16,7 @@ export function buildRichText(
     annotations && Object.keys(annotations).length,
   );
 
-  return chunkString(text, TEXT_CONTENT_MAX_LENGTH).map((content) => {
+  return chunkString(text, LIMITS.TEXT_CONTENT_CHARACTERS).map((content) => {
     const richText: RichTextText = { text: { content } };
     if (hasAnnotations) richText.annotations = annotations;
     if (link) richText.text.link = link;


### PR DESCRIPTION
Notion imposes a [limit](https://developers.notion.com/reference/request-limits#limits-for-property-values) of 100 blocks per request. To comply with this limit, we now batch requests when creating notes so that they contain at most 100 blocks each.