### PR TITLE
feat: Support citation key property and page title format

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,26 +171,27 @@ does not conflict with any of the other property names. The name and type of
 the other properties must be configured exactly as specified here. Note that
 property names are case-sensitive, so the capitalization must match exactly.
 
-| Property Name      | Property Type | Notes                                                                               |
-| ------------------ | ------------- | ----------------------------------------------------------------------------------- |
-| `Name`             | Title         | Format configurable via the **Notion Page Title** option in Notero preferences      |
-| `Abstract`         | Text          |                                                                                     |
-| `Authors`          | Text          |                                                                                     |
-| `Collections`      | Multi-select  |                                                                                     |
-| `Date`             | Text          |                                                                                     |
-| `Date Added`       | Date          |                                                                                     |
-| `DOI`              | URL           |                                                                                     |
-| `Editors`          | Text          |                                                                                     |
-| `File Path`        | Text          |                                                                                     |
-| `Full Citation`    | Text          | Format is based on the Zotero setting for **Export → Quick Copy → Item Format**     |
-| `In-Text Citation` | Text          | Currently APA style, but see issue [#5](https://github.com/dvanoni/notero/issues/5) |
-| `Item Type`        | Select        |                                                                                     |
-| `Short Title`      | Text          |                                                                                     |
-| `Tags`             | Multi-select  |                                                                                     |
-| `Title`            | Text          |                                                                                     |
-| `URL`              | URL           |                                                                                     |
-| `Year`             | Number        |                                                                                     |
-| `Zotero URI`       | URL           | Links do not work; see issue [#172](https://github.com/dvanoni/notero/issues/172)   |
+| Property Name      | Property Type | Notes                                                                             |
+| ------------------ | ------------- | --------------------------------------------------------------------------------- |
+| `Name`             | Title         | Format configurable via the **Notion Page Title** option in Notero preferences    |
+| `Abstract`         | Text          |                                                                                   |
+| `Authors`          | Text          |                                                                                   |
+| `Citation Key`     | Text          | Requires [Better BibTeX](https://retorque.re/zotero-better-bibtex/)               |
+| `Collections`      | Multi-select  |                                                                                   |
+| `Date`             | Text          |                                                                                   |
+| `Date Added`       | Date          |                                                                                   |
+| `DOI`              | URL           |                                                                                   |
+| `Editors`          | Text          |                                                                                   |
+| `File Path`        | Text          |                                                                                   |
+| `Full Citation`    | Text          | Format is based on the Zotero setting for **Export → Quick Copy → Item Format**   |
+| `In-Text Citation` | Text          |                                                                                   |
+| `Item Type`        | Select        |                                                                                   |
+| `Short Title`      | Text          |                                                                                   |
+| `Tags`             | Multi-select  |                                                                                   |
+| `Title`            | Text          |                                                                                   |
+| `URL`              | URL           |                                                                                   |
+| `Year`             | Number        |                                                                                   |
+| `Zotero URI`       | URL           | Links do not work; see issue [#172](https://github.com/dvanoni/notero/issues/172) |
 
 Support for additional properties is planned for the future. See issues:
 [#49](https://github.com/dvanoni/notero/issues/49)

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -47,7 +47,7 @@ async function waitForZotero() {
 
   const { Services } = ChromeUtils.import(
     'resource://gre/modules/Services.jsm',
-  ) as { Services: Services };
+  );
 
   const windows = Services.wm.getEnumerator('navigator:browser');
   let found = false;
@@ -158,7 +158,7 @@ async function startup(
     // eslint-disable-next-line no-var
     var { Services } = ChromeUtils.import(
       'resource://gre/modules/Services.jsm',
-    ) as { Services: Services };
+    );
   }
 
   if (isZotero6()) {

--- a/src/content/prefs/notero-pref.ts
+++ b/src/content/prefs/notero-pref.ts
@@ -9,6 +9,7 @@ export enum NoteroPref {
 
 export enum PageTitleFormat {
   itemAuthorDateCitation = 'itemAuthorDateCitation',
+  itemCitationKey = 'itemCitationKey',
   itemFullCitation = 'itemFullCitation',
   itemInTextCitation = 'itemInTextCitation',
   itemShortTitle = 'itemShortTitle',

--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -15,7 +15,7 @@ class Preferences {
 
     await Zotero.uiReadyPromise;
 
-    this.initPageTitleFormatMenu();
+    await this.initPageTitleFormatMenu();
 
     ReactDOM.render(
       <SyncConfigsTable />,
@@ -23,7 +23,9 @@ class Preferences {
     );
   }
 
-  private initPageTitleFormatMenu(): void {
+  private async initPageTitleFormatMenu(): Promise<void> {
+    const isBetterBibTeXActive = await this.isBetterBibTeXActive();
+
     Object.values(PageTitleFormat).forEach((format) => {
       const label = getLocalizedString(`notero.pageTitleFormat.${format}`);
       const item = this.pageTitleFormatMenu.appendItem(label, format);
@@ -31,8 +33,22 @@ class Preferences {
       if (format === this.pageTitleFormatMenu.value) {
         this.pageTitleFormatMenu.selectedItem = item;
       }
+      if (format === PageTitleFormat.itemCitationKey) {
+        item.disabled = !isBetterBibTeXActive;
+      }
     });
+
     this.pageTitleFormatMenu.disabled = false;
+  }
+
+  private async isBetterBibTeXActive(): Promise<boolean> {
+    const { AddonManager } = ChromeUtils.import(
+      'resource://gre/modules/AddonManager.jsm',
+    );
+    const addon = await AddonManager.getAddonByID(
+      'better-bibtex@iris-advies.com',
+    );
+    return Boolean(addon?.isActive);
   }
 
   public openReadme(): void {

--- a/src/content/sync/__tests__/property-builder.spec.ts
+++ b/src/content/sync/__tests__/property-builder.spec.ts
@@ -20,6 +20,7 @@ const fakeTag = 'Fake Tag';
 const fakeFirstName = 'Fakey';
 const fakeLastName = 'Fakerson';
 const fakeAbstract = 'Fake abstract';
+const fakeCitationKey = 'fakeCitationKey';
 const fakeDate = '2023-10-01';
 const fakePublication = 'Fake Publication';
 const fakeShortTitle = 'Faking It';
@@ -38,6 +39,11 @@ const pageTitleTestCases: {
     description: 'item author-date citation',
     format: PageTitleFormat.itemAuthorDateCitation,
     expected: `${fakeLastName}, ${fakeYear}`,
+  },
+  {
+    description: 'item citation key',
+    format: PageTitleFormat.itemCitationKey,
+    expected: fakeCitationKey,
   },
   {
     description: 'item full citation',
@@ -137,6 +143,7 @@ function setup() {
   ]);
   item.getDisplayTitle.mockReturnValue(fakeTitle);
   item.getField.calledWith('abstractNote').mockReturnValue(fakeAbstract);
+  item.getField.calledWith('citationKey').mockReturnValue(fakeCitationKey);
   item.getField.calledWith('date').mockReturnValue(fakeDate);
   item.getField.calledWith('shortTitle').mockReturnValue(fakeShortTitle);
   item.getField.calledWith('year').mockReturnValue(String(fakeYear));
@@ -165,6 +172,25 @@ describe('buildProperties', () => {
             title: [{ text: { content: expected } }],
           },
         });
+      });
+    });
+
+    it('returns item display title for `itemCitationKey` when citation key is unavailable', async () => {
+      const { item } = setup();
+
+      item.getField.calledWith('citationKey').mockReturnValue('');
+
+      const result = await buildProperties({
+        citationFormat: 'style',
+        databaseProperties: {},
+        item,
+        pageTitleFormat: PageTitleFormat.itemCitationKey,
+      });
+
+      expect(result).toStrictEqual({
+        title: {
+          title: [{ text: { content: fakeTitle } }],
+        },
       });
     });
   });

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -88,6 +88,7 @@ class PropertyBuilder {
   > = {
     [PageTitleFormat.itemAuthorDateCitation]: () =>
       this.getAuthorDateCitation(),
+    [PageTitleFormat.itemCitationKey]: () => this.getCitationKey(),
     [PageTitleFormat.itemFullCitation]: () => this.getFullCitation(),
     [PageTitleFormat.itemInTextCitation]: () => this.getInTextCitation(),
     [PageTitleFormat.itemShortTitle]: () => this.getShortTitle(),
@@ -102,6 +103,10 @@ class PropertyBuilder {
   private async getAuthorDateCitation(): Promise<string | null> {
     const citation = await this.getCachedCitation(APA_STYLE, true);
     return citation?.match(/^\((.+)\)$/)?.[1] || null;
+  }
+
+  private getCitationKey(): string | undefined {
+    return this.item.getField('citationKey');
   }
 
   public getFullCitation(): Promise<string | null> {

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -190,6 +190,11 @@ class PropertyBuilder {
       },
     },
     {
+      name: 'Citation Key',
+      type: 'rich_text',
+      buildRequest: () => buildRichText(this.getCitationKey()),
+    },
+    {
       name: 'Collections',
       type: 'multi_select',
       buildRequest: () =>

--- a/src/locale/en-US/notero.properties
+++ b/src/locale/en-US/notero.properties
@@ -11,6 +11,7 @@ notero.preferences.collectionColumn  = Collection
 notero.preferences.syncEnabledColumn = Sync Enabled
 
 notero.pageTitleFormat.itemAuthorDateCitation = Item Author-Date Citation
+notero.pageTitleFormat.itemCitationKey        = Item Citation Key (requires Better BibTeX)
 notero.pageTitleFormat.itemFullCitation       = Item Full Citation
 notero.pageTitleFormat.itemInTextCitation     = Item In-Text Citation
 notero.pageTitleFormat.itemShortTitle         = Item Short Title

--- a/src/locale/zh-CN/notero.properties
+++ b/src/locale/zh-CN/notero.properties
@@ -11,6 +11,7 @@ notero.preferences.collectionColumn  = 集合
 notero.preferences.syncEnabledColumn = 启用同步
 
 notero.pageTitleFormat.itemAuthorDateCitation = 项目作者-日期引文
+notero.pageTitleFormat.itemCitationKey        = 项目引文密钥（需要 Better BibTeX）
 notero.pageTitleFormat.itemFullCitation       = 项目完整引用
 notero.pageTitleFormat.itemInTextCitation     = 项目文本引用
 notero.pageTitleFormat.itemShortTitle         = 项目短标题

--- a/types/jsm.d.ts
+++ b/types/jsm.d.ts
@@ -1,0 +1,37 @@
+/**
+ * @see https://udn.realityripple.com/docs/Mozilla/JavaScript_code_modules
+ */
+declare namespace jsm {
+  type ModuleURIMap = {
+    'resource://gre/modules/AddonManager.jsm': { AddonManager: AddonManager };
+    'resource://gre/modules/Services.jsm': { Services: Services };
+  };
+
+  interface Addon {
+    readonly isActive: boolean;
+  }
+
+  interface AddonManager {
+    getAddonByID(id: string): Promise<Addon | null>;
+  }
+
+  interface Services {
+    io: XPCOM.nsIIOService;
+    prefs: XPCOM.nsIPrefService;
+    scriptloader: XPCOM.mozIJSSubScriptLoader;
+    strings: XPCOM.nsIStringBundleService;
+    wm: XPCOM.nsIWindowMediator;
+  }
+}
+
+/**
+ * @see https://searchfox.org/mozilla-central/source/dom/chrome-webidl/ChromeUtils.webidl
+ */
+declare const ChromeUtils: {
+  import<URI extends keyof jsm.ModuleURIMap>(
+    aResourceURI: URI,
+    aTargetObj?: object,
+  ): jsm.ModuleURIMap[URI];
+};
+
+declare const Services: jsm.Services;

--- a/types/xpcom.d.ts
+++ b/types/xpcom.d.ts
@@ -147,13 +147,6 @@ declare namespace XPCOM {
 }
 
 /**
- * @see https://searchfox.org/mozilla-central/source/dom/chrome-webidl/ChromeUtils.webidl
- */
-declare const ChromeUtils: {
-  import(aResourceURI: string, aTargetObj?: object): unknown;
-};
-
-/**
  * @see https://udn.realityripple.com/docs/Mozilla/Tech/XPCOM/Language_Bindings
  */
 declare const Components: {
@@ -168,16 +161,3 @@ declare const Components: {
 declare const Cc: typeof Components.classes;
 declare const Ci: typeof Components.interfaces;
 declare const Cu: typeof Components.utils;
-
-/**
- * @see https://udn.realityripple.com/docs/Mozilla/JavaScript_code_modules/Services.jsm
- */
-declare interface Services {
-  io: XPCOM.nsIIOService;
-  prefs: XPCOM.nsIPrefService;
-  scriptloader: XPCOM.mozIJSSubScriptLoader;
-  strings: XPCOM.nsIStringBundleService;
-  wm: XPCOM.nsIWindowMediator;
-}
-
-declare const Services: Services;

--- a/types/xpcom.d.ts
+++ b/types/xpcom.d.ts
@@ -147,6 +147,13 @@ declare namespace XPCOM {
 }
 
 /**
+ * @see https://searchfox.org/mozilla-central/source/dom/chrome-webidl/ChromeUtils.webidl
+ */
+declare const ChromeUtils: {
+  import(aResourceURI: string, aTargetObj?: object): unknown;
+};
+
+/**
  * @see https://udn.realityripple.com/docs/Mozilla/Tech/XPCOM/Language_Bindings
  */
 declare const Components: {
@@ -161,8 +168,6 @@ declare const Components: {
 declare const Cc: typeof Components.classes;
 declare const Ci: typeof Components.interfaces;
 declare const Cu: typeof Components.utils;
-
-declare const ChromeUtils: typeof Components.utils;
 
 /**
  * @see https://udn.realityripple.com/docs/Mozilla/JavaScript_code_modules/Services.jsm

--- a/types/xul.d.ts
+++ b/types/xul.d.ts
@@ -11,7 +11,9 @@ declare namespace XUL {
     checked: boolean;
   }
 
-  type MenuItemElement = XULElement;
+  interface MenuItemElement extends XULElement {
+    disabled: boolean;
+  }
 
   interface MenuListElement extends XULElement {
     appendItem(


### PR DESCRIPTION
The `citationKey` field from [Better BibTeX](https://retorque.re/zotero-better-bibtex/) can now:

- be synced as a **text** property named `Citation Key`
- be used as the title for Notion pages (via a new option named `Item Citation Key`)

The `Item Citation Key` option is only enabled if Better BibTeX is installed and enabled.

Closes #5, closes #254