### PR TITLE
fix: Support parsing notes without container div

### DIFF
--- a/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
@@ -8,6 +8,8 @@ import * as blockquote from './blockquote';
 import * as formatting from './formatting';
 import * as nestedStyles from './nestedStyles';
 import * as simple from './simple';
+import * as textOnly from './textOnly';
+import * as withoutContainer from './withoutContainer';
 
 type NoteTestCase = {
   name: string;
@@ -16,11 +18,13 @@ type NoteTestCase = {
 };
 
 const cases: Record<string, Pick<NoteTestCase, 'expected'>> = {
-  simple,
-  blockquote,
-  nestedStyles,
   annotations,
+  blockquote,
   formatting,
+  nestedStyles,
+  simple,
+  textOnly,
+  withoutContainer,
 };
 
 export const htmlTestCases: NoteTestCase[] = Object.entries(cases).map(

--- a/src/content/sync/html-to-notion/__tests__/fixtures/textOnly.html
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/textOnly.html
@@ -1,0 +1,1 @@
+Text only

--- a/src/content/sync/html-to-notion/__tests__/fixtures/textOnly.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/textOnly.ts
@@ -1,0 +1,9 @@
+import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+
+export const expected: BlockObjectRequest[] = [
+  {
+    paragraph: {
+      rich_text: [{ text: { content: 'Text only' } }],
+    },
+  },
+];

--- a/src/content/sync/html-to-notion/__tests__/fixtures/withoutContainer.html
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/withoutContainer.html
@@ -1,0 +1,2 @@
+<h1>Heading</h1>
+<p>Paragraph</p>

--- a/src/content/sync/html-to-notion/__tests__/fixtures/withoutContainer.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/withoutContainer.ts
@@ -1,0 +1,14 @@
+import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+
+export const expected: BlockObjectRequest[] = [
+  {
+    heading_1: {
+      rich_text: [{ text: { content: 'Heading' } }],
+    },
+  },
+  {
+    paragraph: {
+      rich_text: [{ text: { content: 'Paragraph' } }],
+    },
+  },
+];

--- a/src/content/sync/html-to-notion/__tests__/html-to-notion.spec.ts
+++ b/src/content/sync/html-to-notion/__tests__/html-to-notion.spec.ts
@@ -3,14 +3,6 @@ import { convertHtmlToBlocks } from '../html-to-notion';
 import { htmlTestCases } from './fixtures';
 
 describe('convertHtmlToBlocks', () => {
-  it('throws error if HTML content does not match expected format', () => {
-    const html = '<h1>Unexpected</h1>';
-
-    expect(() => convertHtmlToBlocks(html)).toThrow(
-      new Error('Failed to load HTML content'),
-    );
-  });
-
   it.each(htmlTestCases)(
     'returns expected blocks for "$name"',
     ({ html, expected }) => {

--- a/src/content/sync/html-to-notion/dom-utils.ts
+++ b/src/content/sync/html-to-notion/dom-utils.ts
@@ -27,6 +27,7 @@ export function isHTMLElement(node: Node): node is HTMLElement {
 
 export function getRootElement(htmlString: string): Element | null {
   const domParser = getDOMParser();
-  const doc = domParser.parseFromString(htmlString, 'text/html');
-  return doc.querySelector('body > div[data-schema-version]');
+  const { body } = domParser.parseFromString(htmlString, 'text/html');
+  const containerDiv = body.querySelector('div[data-schema-version]');
+  return containerDiv || body;
 }

--- a/src/content/sync/html-to-notion/parse-node.ts
+++ b/src/content/sync/html-to-notion/parse-node.ts
@@ -175,6 +175,7 @@ export function parseNode(node: Node): ParsedNode | undefined {
       return parseBlockElement(node, 'quote');
     case 'BR':
       return { type: 'br' };
+    case 'BODY':
     case 'DIV':
     case 'P':
       return parseBlockElement(node, 'paragraph');


### PR DESCRIPTION
Some notes generated by Zotero do not include the containing `<div data-schema-version="8">...</div>` element. This PR adds support for such notes.

Fixes #403