### PR TITLE
feat: Replace Notion database ID text field with selection menu

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/commitlintrc.json",
   "extends": ["@commitlint/config-conventional"],
   "rules": {
     "subject-case": [2, "always", "sentence-case"]

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 build
 gen
 node_modules
-esbuild.js
 .eslintrc.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://json.schemastore.org/prettierrc.json",
   "singleQuote": true
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc.json",
-  "singleQuote": true
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": ["*.xhtml", "*.xul"],
+      "options": { "parser": "html" }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -144,20 +144,7 @@ Detailed setup instructions are below.
         />
       </details>
 
-5.  Take note of the database ID.
-
-    To get the database ID, copy the URL of your Notion database. If you're
-    using an inline database, then make sure you're viewing the database as a
-    full page. If you're using the Notion desktop app, then click **Share**
-    and select **Copy link** to find the database URL.
-
-    The database ID is the string of characters in the database URL that is
-    between the slash following your workspace name (if you named it) and the
-    question mark. The ID is 32 characters long, containing numbers and letters.
-
-    ![Notion database ID](https://files.readme.io/62e5027-notion_database_id.png)
-
-6.  Configure the database properties as desired. See the
+5.  Configure the database properties as desired. See the
     [database properties](#notion-database-properties) section below for more details.
 
 #### Notion Database Properties
@@ -213,8 +200,7 @@ see issue [#355](https://github.com/dvanoni/notero/issues/355).
    - dragging and dropping it into the Add-ons Manager window _or_
    - selecting it using the **Install Add-on From File...** option in the
      gear menu in the top-right corner of the window
-4. Restart Zotero to activate the plugin.
-5. Open the Notero preferences from the **Tools → Notero Preferences...** menu
+4. Open the Notero preferences from the **Tools → Notero Preferences...** menu
    item, and enter the required preferences.
    - Note for Zotero 7 users: The Notero preferences have moved into a section
      in the main Zotero preferences window.

--- a/README.md
+++ b/README.md
@@ -254,17 +254,6 @@ See the [Syncing Items](#syncing-items) section above.
 
 ### How to fix Notion API errors
 
-#### Invalid request URL
-
-If you receive the following error:
-
-> APIResponseError: Invalid request URL.
-
-This usually occurs when there's something amiss with the database ID entered in
-the Notero preferences. Double check that the database ID follows the format
-described in the [Configure Notion](#configure-notion) section. It should be 32
-characters consisting of only numbers and letters.
-
 #### Could not find database
 
 If you receive the following error:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@notionhq/client": "^2.2.13",
-        "core-js": "^3.31.1",
+        "core-js-pure": "^3.35.0",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
@@ -3717,10 +3717,10 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/core-js": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.1.tgz",
-      "integrity": "sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==",
+    "node_modules/core-js-pure": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.35.0.tgz",
+      "integrity": "sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^2.2.13",
-    "core-js": "^3.31.1",
+    "core-js-pure": "^3.35.0",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {

--- a/patches/@notionhq+client+2.2.13.patch
+++ b/patches/@notionhq+client+2.2.13.patch
@@ -32,3 +32,19 @@ index 390de9c..8faf72a 100644
          __classPrivateFieldSet(this, _Client_agent, options === null || options === void 0 ? void 0 : options.agent, "f");
          __classPrivateFieldSet(this, _Client_userAgent, `notionhq-client/${package_json_1.version}`, "f");
      }
+diff --git a/node_modules/@notionhq/client/build/src/utils.js b/node_modules/@notionhq/client/build/src/utils.js
+index 3a71c2d..0fe389e 100644
+--- a/node_modules/@notionhq/client/build/src/utils.js
++++ b/node_modules/@notionhq/client/build/src/utils.js
+@@ -14,7 +14,10 @@ function assertNever(value) {
+ exports.assertNever = assertNever;
+ function pick(base, keys) {
+     const entries = keys.map(key => [key, base === null || base === void 0 ? void 0 : base[key]]);
+-    return Object.fromEntries(entries);
++    return entries.reduce((obj, [key, value]) => {
++      obj[key] = value;
++      return obj;
++    }, {});
+ }
+ exports.pick = pick;
+ function isObject(o) {

--- a/src/content/prefs/notero-pref.ts
+++ b/src/content/prefs/notero-pref.ts
@@ -52,15 +52,10 @@ function getPageTitleFormatPref(
   return isPageTitleFormat(value) ? value : undefined;
 }
 
-export function clearNoteroPref(pref: NoteroPref): void {
-  Zotero.Prefs.clear(buildFullPrefName(pref), true);
-}
-
-export function getNoteroPref<P extends NoteroPref>(
+function convertRawPrefValue<P extends NoteroPref>(
   pref: P,
+  value: Zotero.Prefs.Value,
 ): NoteroPrefValue[P] {
-  const value = Zotero.Prefs.get(buildFullPrefName(pref), true);
-
   const booleanPref = getBooleanPref(value);
   const stringPref = getStringPref(value);
 
@@ -78,9 +73,37 @@ export function getNoteroPref<P extends NoteroPref>(
   }[pref];
 }
 
+export function clearNoteroPref(pref: NoteroPref): void {
+  Zotero.Prefs.clear(buildFullPrefName(pref), true);
+}
+
+export function getNoteroPref<P extends NoteroPref>(
+  pref: P,
+): NoteroPrefValue[P] {
+  const value = Zotero.Prefs.get(buildFullPrefName(pref), true);
+  return convertRawPrefValue(pref, value);
+}
+
 export function setNoteroPref<P extends NoteroPref>(
   pref: P,
   value: NoteroPrefValue[P],
 ): void {
   Zotero.Prefs.set(buildFullPrefName(pref), value, true);
+}
+
+export function registerNoteroPrefObserver<P extends NoteroPref>(
+  pref: P,
+  handler: (value: NoteroPrefValue[P]) => void,
+): symbol {
+  return Zotero.Prefs.registerObserver(
+    buildFullPrefName(pref),
+    (value: Zotero.Prefs.Value) => {
+      handler(convertRawPrefValue(pref, value));
+    },
+    true,
+  );
+}
+
+export function unregisterNoteroPrefObserver(symbol: symbol): void {
+  Zotero.Prefs.unregisterObserver(symbol);
 }

--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -1,21 +1,76 @@
+import type { DatabaseObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import ReactDOM from 'react-dom';
 
-import { getLocalizedString, getXULElementById } from '../utils';
+import { IS_ZOTERO_7 } from '../constants';
+import { getNotionClient } from '../sync/notion-client';
+import { isFullDatabase } from '../sync/notion-utils';
+import {
+  getLocalizedString,
+  getXULElementById,
+  hasErrorStack,
+  log,
+} from '../utils';
 
-import { PageTitleFormat } from './notero-pref';
+import {
+  NoteroPref,
+  PageTitleFormat,
+  getNoteroPref,
+  registerNoteroPrefObserver,
+  unregisterNoteroPrefObserver,
+} from './notero-pref';
 import { SyncConfigsTable } from './sync-configs-table';
 
+type MenuItem = {
+  disabled?: boolean;
+  label: string;
+  selected?: boolean;
+  value?: string;
+};
+
+function setMenuItems(menuList: XUL.MenuListElement, items: MenuItem[]): void {
+  menuList.removeAllItems();
+
+  items.forEach(({ disabled, label, selected, value }) => {
+    const item = menuList.appendItem(label, value);
+    item.disabled = Boolean(disabled);
+    if (selected) {
+      menuList.selectedItem = item;
+    }
+  });
+}
+
 class Preferences {
+  private notionDatabaseError!: XUL.DescriptionElement;
+  private notionDatabaseMenu!: XUL.MenuListElement;
   private pageTitleFormatMenu!: XUL.MenuListElement;
+  private prefObserverSymbol!: symbol;
 
   public async init(): Promise<void> {
-    this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat');
-
     await Zotero.uiReadyPromise;
 
+    this.notionDatabaseError = getXULElementById('notero-notionDatabaseError');
+    this.notionDatabaseMenu = getXULElementById('notero-notionDatabase');
+    this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat');
+
+    this.prefObserverSymbol = registerNoteroPrefObserver(
+      NoteroPref.notionToken,
+      () => {
+        void this.refreshNotionDatabaseMenu();
+      },
+    );
+
+    window.addEventListener('unload', () => {
+      this.deinit();
+    });
+
     await this.initPageTitleFormatMenu();
+
+    // Don't block window from loading while waiting for network response
+    setTimeout(() => {
+      void this.refreshNotionDatabaseMenu();
+    }, 100);
 
     ReactDOM.render(
       <SyncConfigsTable />,
@@ -23,21 +78,25 @@ class Preferences {
     );
   }
 
+  private deinit(): void {
+    unregisterNoteroPrefObserver(this.prefObserverSymbol);
+  }
+
   private async initPageTitleFormatMenu(): Promise<void> {
     const isBetterBibTeXActive = await this.isBetterBibTeXActive();
 
-    Object.values(PageTitleFormat).forEach((format) => {
-      const label = getLocalizedString(`notero.pageTitleFormat.${format}`);
-      const item = this.pageTitleFormatMenu.appendItem(label, format);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-      if (format === this.pageTitleFormatMenu.value) {
-        this.pageTitleFormatMenu.selectedItem = item;
-      }
-      if (format === PageTitleFormat.itemCitationKey) {
-        item.disabled = !isBetterBibTeXActive;
-      }
-    });
+    const menuItems = Object.values(PageTitleFormat).map<MenuItem>(
+      (format) => ({
+        disabled:
+          format === PageTitleFormat.itemCitationKey && !isBetterBibTeXActive,
+        label: getLocalizedString(`notero.pageTitleFormat.${format}`),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+        selected: format === this.pageTitleFormatMenu.value,
+        value: format,
+      }),
+    );
 
+    setMenuItems(this.pageTitleFormatMenu, menuItems);
     this.pageTitleFormatMenu.disabled = false;
   }
 
@@ -53,6 +112,62 @@ class Preferences {
 
   public openReadme(): void {
     Zotero.launchURL('https://github.com/dvanoni/notero#readme');
+  }
+
+  private async refreshNotionDatabaseMenu(): Promise<void> {
+    let menuItems: MenuItem[] = [];
+
+    try {
+      const databaseID = getNoteroPref(NoteroPref.notionDatabaseID);
+      const databases = await this.retrieveNotionDatabases();
+
+      menuItems = databases.map<MenuItem>((database) => {
+        const idWithoutDashes = database.id.replace(/-/g, '');
+        const title = database.title.map((t) => t.plain_text).join('');
+        const icon =
+          IS_ZOTERO_7 && database.icon?.type === 'emoji'
+            ? database.icon.emoji
+            : null;
+
+        return {
+          label: icon ? `${icon} ${title}` : title,
+          value: idWithoutDashes,
+          selected: idWithoutDashes === databaseID,
+        };
+      });
+
+      this.notionDatabaseMenu.disabled = false;
+      this.notionDatabaseError.hidden = true;
+    } catch (error) {
+      this.notionDatabaseMenu.disabled = true;
+      this.notionDatabaseError.hidden = false;
+      this.notionDatabaseError.value =
+        error instanceof Error ? error.message : String(error);
+    }
+
+    setMenuItems(this.notionDatabaseMenu, menuItems);
+  }
+
+  private async retrieveNotionDatabases(): Promise<DatabaseObjectResponse[]> {
+    try {
+      const notion = getNotionClient(window);
+
+      const response = await notion.search({
+        filter: { property: 'object', value: 'database' },
+      });
+
+      const databases = response.results.filter(isFullDatabase);
+
+      if (databases.length === 0) {
+        throw new Error('No databases are accessible');
+      }
+
+      return databases;
+    } catch (error) {
+      log(String(error), 'error');
+      if (hasErrorStack(error)) log(error.stack, 'error');
+      throw error;
+    }
   }
 }
 

--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -2,7 +2,7 @@
   <html:link rel="localization" href="notero.ftl" />
 </linkset>
 
-<!-- The `notero` variable used below is defined in `esbuild.js` -->
+<!-- The `notero` variable used below is defined in `scripts/build.ts` -->
 <vbox onload="notero.preferences.init();">
   <vbox class="main-section">
     <html:h1 data-l10n-id="notero-preferences-notion-groupbox-heading" />
@@ -22,14 +22,16 @@
         preference="extensions.notero.notionToken"
         type="text"
       />
-      <label control="notero-notionDatabaseID">
-        <html:h2 data-l10n-id="notero-preferences-notion-database-id" />
+      <label control="notero-notionDatabase">
+        <html:h2 data-l10n-id="notero-preferences-notion-database" />
       </label>
-      <html:input
-        id="notero-notionDatabaseID"
+      <menulist
+        id="notero-notionDatabase"
+        disabled="true"
+        native="true"
         preference="extensions.notero.notionDatabaseID"
-        type="text"
       />
+      <description id="notero-notionDatabaseError" hidden="true" />
     </groupbox>
   </vbox>
 

--- a/src/content/prefs/preferences.xul
+++ b/src/content/prefs/preferences.xul
@@ -6,7 +6,7 @@
 <?xml-stylesheet href="chrome://notero/content/style/preferences.css" type="text/css"?>
 <!DOCTYPE prefwindow SYSTEM "chrome://notero/locale/notero.dtd">
 
-<!-- The `notero` variable used below is defined in `esbuild.js` -->
+<!-- The `notero` variable used below is defined in `scripts/build.ts` -->
 <prefwindow
   id="notero-prefwindow"
   title="&notero.preferences.title;"
@@ -22,6 +22,7 @@
       />
       <preference
         id="pref-notionToken"
+        instantApply="true"
         name="extensions.notero.notionToken"
         type="string"
       />
@@ -66,14 +67,16 @@
       <textbox id="notero-notionToken" preference="pref-notionToken" />
       <separator class="thin" />
       <label
-        id="notero-notionDatabaseID-label"
-        value="&notero.preferences.notionDatabaseID;"
-        control="notero-notionDatabaseID"
+        id="notero-notionDatabase-label"
+        value="&notero.preferences.notionDatabase;"
+        control="notero-notionDatabase"
       />
-      <textbox
-        id="notero-notionDatabaseID"
+      <menulist
+        id="notero-notionDatabase"
+        disabled="true"
         preference="pref-notionDatabaseID"
       />
+      <description id="notero-notionDatabaseError" hidden="true" />
     </groupbox>
 
     <separator class="thin" />

--- a/src/content/prefs/preferences.xul
+++ b/src/content/prefs/preferences.xul
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- prettier-ignore -->
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/preferences.css" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/zotero-react-client.css" type="text/css"?>
@@ -7,63 +8,92 @@
 
 <!-- The `notero` variable used below is defined in `esbuild.js` -->
 <prefwindow
-    id="notero-prefwindow"
-    title="&notero.preferences.title;"
-    xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-    xmlns:html="http://www.w3.org/1999/xhtml"
+  id="notero-prefwindow"
+  title="&notero.preferences.title;"
+  xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  xmlns:html="http://www.w3.org/1999/xhtml"
 >
   <prefpane id="notero-prefpane" onpaneload="notero.preferences.init();">
     <preferences>
-      <preference id="pref-collectionSyncConfigs"
-                  name="extensions.notero.collectionSyncConfigs"
-                  type="string" />
-      <preference id="pref-notionToken" name="extensions.notero.notionToken" type="string" />
-      <preference id="pref-notionDatabaseID"
-                  name="extensions.notero.notionDatabaseID"
-                  type="string" />
-      <preference id="pref-pageTitleFormat"
-                  name="extensions.notero.pageTitleFormat"
-                  type="string" />
-      <preference id="pref-syncNotes"
-                  name="extensions.notero.syncNotes"
-                  type="bool" />
-      <preference id="pref-syncOnModifyItems"
-                  name="extensions.notero.syncOnModifyItems"
-                  type="bool" />
+      <preference
+        id="pref-collectionSyncConfigs"
+        name="extensions.notero.collectionSyncConfigs"
+        type="string"
+      />
+      <preference
+        id="pref-notionToken"
+        name="extensions.notero.notionToken"
+        type="string"
+      />
+      <preference
+        id="pref-notionDatabaseID"
+        name="extensions.notero.notionDatabaseID"
+        type="string"
+      />
+      <preference
+        id="pref-pageTitleFormat"
+        name="extensions.notero.pageTitleFormat"
+        type="string"
+      />
+      <preference
+        id="pref-syncNotes"
+        name="extensions.notero.syncNotes"
+        type="bool"
+      />
+      <preference
+        id="pref-syncOnModifyItems"
+        name="extensions.notero.syncOnModifyItems"
+        type="bool"
+      />
     </preferences>
 
     <groupbox>
       <caption label="&notero.preferences.notionGroupboxCaption;" />
       <description>
         &notero.preferences.notionGroupboxDescription;
-        <label class="text-link"
-               onclick="notero.preferences.openReadme();"
-               value="&notero.preferences.readme;" />.
+        <label
+          class="text-link"
+          onclick="notero.preferences.openReadme();"
+          value="&notero.preferences.readme;"
+        />.
       </description>
       <separator class="thin" />
-      <label id="notero-notionToken-label"
-             value="&notero.preferences.notionToken;"
-             control="notero-notionToken" />
+      <label
+        id="notero-notionToken-label"
+        value="&notero.preferences.notionToken;"
+        control="notero-notionToken"
+      />
       <textbox id="notero-notionToken" preference="pref-notionToken" />
       <separator class="thin" />
-      <label id="notero-notionDatabaseID-label"
-             value="&notero.preferences.notionDatabaseID;"
-             control="notero-notionDatabaseID" />
-      <textbox id="notero-notionDatabaseID" preference="pref-notionDatabaseID" />
+      <label
+        id="notero-notionDatabaseID-label"
+        value="&notero.preferences.notionDatabaseID;"
+        control="notero-notionDatabaseID"
+      />
+      <textbox
+        id="notero-notionDatabaseID"
+        preference="pref-notionDatabaseID"
+      />
     </groupbox>
 
     <separator class="thin" />
 
     <groupbox>
       <caption label="&notero.preferences.propertiesGroupboxCaption;" />
-      <description>&notero.preferences.propertiesGroupboxDescription;</description>
+      <description
+        >&notero.preferences.propertiesGroupboxDescription;</description
+      >
       <separator class="thin" />
-      <label id="notero-pageTitleFormat-label"
-             value="&notero.preferences.pageTitleFormat;"
-             control="notero-pageTitleFormat" />
-      <menulist id="notero-pageTitleFormat"
-                disabled="true"
-                preference="pref-pageTitleFormat" />
+      <label
+        id="notero-pageTitleFormat-label"
+        value="&notero.preferences.pageTitleFormat;"
+        control="notero-pageTitleFormat"
+      />
+      <menulist
+        id="notero-pageTitleFormat"
+        disabled="true"
+        preference="pref-pageTitleFormat"
+      />
     </groupbox>
 
     <separator class="thin" />
@@ -77,12 +107,16 @@
         <html:div id="notero-syncConfigsTable-container" />
       </hbox>
       <separator class="thin" />
-      <checkbox id="notero-syncOnModifyItems"
-                label="&notero.preferences.syncOnModifyItems;"
-                preference="pref-syncOnModifyItems" />
-      <checkbox id="notero-syncNotes"
-                label="&notero.preferences.syncNotes;"
-                preference="pref-syncNotes" />
+      <checkbox
+        id="notero-syncOnModifyItems"
+        label="&notero.preferences.syncOnModifyItems;"
+        preference="pref-syncOnModifyItems"
+      />
+      <checkbox
+        id="notero-syncNotes"
+        label="&notero.preferences.syncNotes;"
+        preference="pref-syncNotes"
+      />
     </groupbox>
   </prefpane>
 

--- a/src/content/style/preferences.css
+++ b/src/content/style/preferences.css
@@ -13,3 +13,7 @@
 #notero-prefpane label.text-link {
   margin: 0;
 }
+
+#notero-notionDatabaseError {
+  color: darkred;
+}

--- a/src/content/sync/html-to-notion/html-to-notion.ts
+++ b/src/content/sync/html-to-notion/html-to-notion.ts
@@ -1,5 +1,5 @@
-import 'core-js/stable/string/trim-end';
-import 'core-js/stable/string/trim-start';
+import trimEnd from 'core-js-pure/es/string/trim-end';
+import trimStart from 'core-js-pure/es/string/trim-start';
 
 import { keyValue } from '../../utils';
 import {
@@ -295,11 +295,9 @@ function trimRichText(richText: RichText): RichText {
     return updateContent(0, (content) => content.trim());
   }
 
-  const first = updateContent(0, (content) => content.trimStart());
+  const first = updateContent(0, trimStart);
   const middle = richText.slice(1, -1);
-  const last = updateContent(richText.length - 1, (content) =>
-    content.trimEnd(),
-  );
+  const last = updateContent(richText.length - 1, trimEnd);
 
   return [...first, ...middle, ...last];
 }

--- a/src/content/sync/notion-client.ts
+++ b/src/content/sync/notion-client.ts
@@ -1,5 +1,4 @@
 import { Client, Logger, LogLevel } from '@notionhq/client';
-import 'core-js/stable/object/from-entries';
 
 import { getNoteroPref, NoteroPref } from '../prefs/notero-pref';
 import { getLocalizedString, log } from '../utils';

--- a/src/content/sync/notion-utils/index.ts
+++ b/src/content/sync/notion-utils/index.ts
@@ -1,4 +1,5 @@
 export { buildDate } from './build-date';
 export { buildRichText } from './build-rich-text';
 export { isNotionErrorWithCode } from './error';
+export { isFullDatabase } from './is-full-database';
 export { convertWebURLToAppURL, getPageIDFromURL, isNotionURL } from './url';

--- a/src/content/sync/notion-utils/is-full-database.ts
+++ b/src/content/sync/notion-utils/is-full-database.ts
@@ -1,0 +1,17 @@
+import { isFullPageOrDatabase } from '@notionhq/client';
+import type {
+  DatabaseObjectResponse,
+  PageObjectResponse,
+  PartialDatabaseObjectResponse,
+  PartialPageObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+export function isFullDatabase(
+  response:
+    | DatabaseObjectResponse
+    | PartialDatabaseObjectResponse
+    | PageObjectResponse
+    | PartialPageObjectResponse,
+): response is DatabaseObjectResponse {
+  return isFullPageOrDatabase(response) && response.object === 'database';
+}

--- a/src/locale/en-US/notero.dtd
+++ b/src/locale/en-US/notero.dtd
@@ -8,7 +8,7 @@
 <!ENTITY notero.preferences.notionGroupboxDescription "For instructions on obtaining these values, view the ">
 <!ENTITY notero.preferences.readme "README">
 <!ENTITY notero.preferences.notionToken "Integration Token">
-<!ENTITY notero.preferences.notionDatabaseID "Database ID">
+<!ENTITY notero.preferences.notionDatabase "Database">
 
 <!ENTITY notero.preferences.propertiesGroupboxCaption "Property Preferences">
 <!ENTITY notero.preferences.propertiesGroupboxDescription "Customize how item properties sync to Notion.">

--- a/src/locale/en-US/notero.ftl
+++ b/src/locale/en-US/notero.ftl
@@ -6,7 +6,7 @@ notero-preferences-notion-groupbox-description =
   <label data-l10n-name="notero-preferences-readme">README</label>.
 
 notero-preferences-notion-token = Integration Token
-notero-preferences-notion-database-id = Database ID
+notero-preferences-notion-database = Database
 
 ## Property preferences
 

--- a/src/locale/zh-CN/notero.dtd
+++ b/src/locale/zh-CN/notero.dtd
@@ -8,7 +8,7 @@
 <!ENTITY notero.preferences.notionGroupboxDescription "有关获取这些值的说明，请查看 ">
 <!ENTITY notero.preferences.readme "README">
 <!ENTITY notero.preferences.notionToken "内部集成令牌">
-<!ENTITY notero.preferences.notionDatabaseID "数据库 ID">
+<!ENTITY notero.preferences.notionDatabase "数据库">
 
 <!ENTITY notero.preferences.propertiesGroupboxCaption "属性偏好">
 <!ENTITY notero.preferences.propertiesGroupboxDescription "自定义项目属性如何同步到 Notion。">

--- a/src/locale/zh-CN/notero.ftl
+++ b/src/locale/zh-CN/notero.ftl
@@ -5,7 +5,7 @@ notero-preferences-notion-groupbox-description =
     有关获取这些值的说明，请查看
     <label data-l10n-name="notero-preferences-readme">README</label>.
 notero-preferences-notion-token = 内部集成令牌
-notero-preferences-notion-database-id = 数据库 ID
+notero-preferences-notion-database = 数据库
 
 ## Property preferences
 
@@ -24,7 +24,7 @@ notero-preferences-sync-groupbox-description2 =
     要选择多行，请按住 { "[Shift]" } 然后单击。
 notero-preferences-collection-column = 集合
 notero-preferences-sync-enabled-column = 启用同步
-notero-preferences-sync-on-modify-items = 
+notero-preferences-sync-on-modify-items =
     .label = 当修改条目时同步
-notero-preferences-sync-notes = 
+notero-preferences-sync-notes =
     .label = 同步笔记

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig.json",
   "compilerOptions": {
     "disableSizeLimit": true,
     "downlevelIteration": true,

--- a/types/core-js-pure.d.ts
+++ b/types/core-js-pure.d.ts
@@ -1,0 +1,9 @@
+declare module 'core-js-pure/es/string/trim-end' {
+  function trimEnd(str: string): string;
+  export = trimEnd;
+}
+
+declare module 'core-js-pure/es/string/trim-start' {
+  function trimStart(str: string): string;
+  export = trimStart;
+}

--- a/types/xul.d.ts
+++ b/types/xul.d.ts
@@ -1,6 +1,7 @@
 /**
  * @see https://www.xulplanet.com/references/elemref/
  * @see https://udn.realityripple.com/docs/Archive/Mozilla/XUL/XUL_Reference
+ * @see https://udn.realityripple.com/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIDOMXULElement
  */
 declare namespace XUL {
   interface ButtonElement extends XULElement {
@@ -9,6 +10,10 @@ declare namespace XUL {
 
   interface CheckboxElement extends XULElement {
     checked: boolean;
+  }
+
+  interface DescriptionElement extends XULElement {
+    value: string;
   }
 
   interface MenuItemElement extends XULElement {
@@ -22,6 +27,7 @@ declare namespace XUL {
       description?: string,
     ): MenuItemElement;
     disabled: boolean;
+    removeAllItems(): void;
     selectedIndex: number;
     selectedItem: MenuItemElement | null;
     value: string;
@@ -41,7 +47,9 @@ declare namespace XUL {
     view?: XPCOM.nsITreeView;
   }
 
-  type XULElement = Element;
+  interface XULElement extends Element {
+    hidden: boolean;
+  }
 
   type XULElementTagNameMap = {
     button: ButtonElement;


### PR DESCRIPTION
Replace the "Database ID" text field with a selection menu that lists the databases which Notero has access to. This enables directly selecting the desired Notion database instead of having to correctly obtain and paste the database ID. Trouble with this process has been the cause of at least 15 issues: #59 #60 #62 #71 #87 #116 #193 #217 #224 #249 #292 #349 #373 #380 #387

## Screenshots

| Before | After |
|--------|--------|
| ![CleanShot 2023-12-31 at 17 54 35@2x](https://github.com/dvanoni/notero/assets/299357/f68e083a-183f-4587-a782-3d45c64c78b4) | ![CleanShot 2023-12-31 at 17 51 25@2x](https://github.com/dvanoni/notero/assets/299357/61665d95-281e-4a7a-9602-a763cb8e492f) |

## Changes to polyfills

The polyfill for `Object.fromEntries` used by `@notionhq/client` was not working in the Notero preferences window because the global object could not be correctly obtained. As such, the call to `Object.fromEntries` has been replaced with a patch.

The only other polyfills in use were `String.prototype.trimEnd` and `String.prototype.trimStart` used by `html-to-notion.ts`. In this case, we were able to replace these with the "pure" versions from `core-js-pure`.

Switching from `core-js` to `core-js-pure` was able to resolve #319.

## Other changes

- `xhtml` and `xul` files are now formatted with Prettier.
- JSON schema definitions are added to config files to support validation and auto-complete.