### PR TITLE
ci: Remove unnecessary `packages: read` permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
With #404, we no longer need to authenticate with the GitHub npm registry and thus can remove the permission for accessing it from CI.