### PR TITLE
feat: Add utility for finding duplicate Notion pages

### DIFF
--- a/src/content/data/__tests__/item-data.spec.ts
+++ b/src/content/data/__tests__/item-data.spec.ts
@@ -1,4 +1,4 @@
-import { createZoteroItemMock } from '../../../../test/utils/zotero-mock';
+import { createZoteroItemMock } from '../../../../test/utils';
 import { getSyncedNotesFromAttachment } from '../item-data';
 
 describe('getSyncedNotesFromAttachment', () => {

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -1,3 +1,5 @@
+import type { Client } from '@notionhq/client';
+
 import { IS_ZOTERO_7 } from './constants';
 import type { PluginInfo } from './plugin-info';
 import {
@@ -10,6 +12,8 @@ import {
   UIManager,
   WindowManager,
 } from './services';
+import { findDuplicates } from './sync/find-duplicates';
+import { getNotionClient } from './sync/notion-client';
 import { log } from './utils';
 
 if (!IS_ZOTERO_7) {
@@ -96,6 +100,17 @@ export class Notero {
       log(`Removing ${service.constructor.name} from window`);
       service.removeFromWindow(window);
     });
+  }
+
+  public getNotionClient(): Client {
+    const latestWindow = this.windowManager.getLatestWindow();
+    if (!latestWindow) throw new Error('No window available');
+
+    return getNotionClient(latestWindow);
+  }
+
+  public findDuplicates(): Promise<Set<string>> {
+    return findDuplicates(this.getNotionClient());
   }
 }
 

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -8,6 +8,7 @@ import {
   Service,
   SyncManager,
   UIManager,
+  WindowManager,
 } from './services';
 import { log } from './utils';
 
@@ -17,16 +18,19 @@ if (!IS_ZOTERO_7) {
 
 export class Notero {
   private readonly eventManager: EventManager;
+  private readonly windowManager: WindowManager;
   private readonly services: Service[];
 
   public constructor() {
     this.eventManager = new EventManager();
+    this.windowManager = new WindowManager();
 
     this.services = [
       ...(IS_ZOTERO_7
         ? [new ChromeManager(), new PreferencePaneManager()]
         : [new DefaultPreferencesLoader()]),
       this.eventManager,
+      this.windowManager,
       new SyncManager(),
       new UIManager(),
     ];
@@ -45,7 +49,10 @@ export class Notero {
   }
 
   private startServices(pluginInfo: PluginInfo) {
-    const dependencies = { eventManager: this.eventManager };
+    const dependencies = {
+      eventManager: this.eventManager,
+      windowManager: this.windowManager,
+    };
 
     this.services.forEach((service) => {
       log(`Starting ${service.constructor.name}`);

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -109,8 +109,8 @@ export class Notero {
     return getNotionClient(latestWindow);
   }
 
-  public findDuplicates(): Promise<Set<string>> {
-    return findDuplicates(this.getNotionClient());
+  public findDuplicates(propertyName: string = 'title'): Promise<Set<string>> {
+    return findDuplicates(this.getNotionClient(), propertyName);
   }
 }
 

--- a/src/content/prefs/notero-pref.ts
+++ b/src/content/prefs/notero-pref.ts
@@ -1,3 +1,5 @@
+import { getLocalizedString } from '../utils';
+
 export enum NoteroPref {
   collectionSyncConfigs = 'collectionSyncConfigs',
   notionDatabaseID = 'notionDatabaseID',
@@ -82,6 +84,16 @@ export function getNoteroPref<P extends NoteroPref>(
 ): NoteroPrefValue[P] {
   const value = Zotero.Prefs.get(buildFullPrefName(pref), true);
   return convertRawPrefValue(pref, value);
+}
+
+export function getRequiredNoteroPref<P extends NoteroPref>(
+  pref: P,
+): NonNullable<NoteroPrefValue[P]> {
+  const value = getNoteroPref(pref);
+
+  if (value) return value;
+
+  throw new Error(`Missing ${getLocalizedString(pref)}`);
 }
 
 export function setNoteroPref<P extends NoteroPref>(

--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -50,9 +50,11 @@ class Preferences {
   public async init(): Promise<void> {
     await Zotero.uiReadyPromise;
 
-    this.notionDatabaseError = getXULElementById('notero-notionDatabaseError');
-    this.notionDatabaseMenu = getXULElementById('notero-notionDatabase');
-    this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat');
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    this.notionDatabaseError = getXULElementById('notero-notionDatabaseError')!;
+    this.notionDatabaseMenu = getXULElementById('notero-notionDatabase')!;
+    this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat')!;
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     this.prefObserverSymbol = registerNoteroPrefObserver(
       NoteroPref.notionToken,

--- a/src/content/services/__tests__/sync-manager.spec.ts
+++ b/src/content/services/__tests__/sync-manager.spec.ts
@@ -1,11 +1,11 @@
 import { mock } from 'jest-mock-extended';
 
-import { createWindowMock } from '../../../../test/utils/window-mock';
 import {
+  createWindowMock,
   createZoteroCollectionMock,
   createZoteroItemMock,
   mockZoteroPrefs,
-} from '../../../../test/utils/zotero-mock';
+} from '../../../../test/utils';
 import { getSyncedNotes } from '../../data/item-data';
 import { saveSyncConfigs } from '../../prefs/collection-sync-config';
 import { NoteroPref, setNoteroPref } from '../../prefs/notero-pref';

--- a/src/content/services/__tests__/window-manager.spec.ts
+++ b/src/content/services/__tests__/window-manager.spec.ts
@@ -1,0 +1,40 @@
+import { createWindowMock } from '../../../../test/utils/window-mock';
+import { WindowManager } from '../window-manager';
+
+describe('WindowManager.getLatestWindow', () => {
+  it('returns the latest available window', () => {
+    const windowManager = new WindowManager();
+
+    const window1 = createWindowMock();
+    const window2 = createWindowMock();
+    const window3 = createWindowMock();
+
+    windowManager.addToWindow(window1);
+    windowManager.addToWindow(window2);
+    windowManager.addToWindow(window3);
+    windowManager.removeFromWindow(window2);
+
+    expect(windowManager.getLatestWindow()).toBe(window3);
+
+    windowManager.removeFromWindow(window3);
+
+    expect(windowManager.getLatestWindow()).toBe(window1);
+  });
+
+  it('returns undefined when all windows have been removed', () => {
+    const windowManager = new WindowManager();
+
+    const window1 = createWindowMock();
+    const window2 = createWindowMock();
+
+    windowManager.addToWindow(window1);
+    windowManager.addToWindow(window2);
+    windowManager.removeFromWindow(window1);
+
+    expect(windowManager.getLatestWindow()).toBe(window2);
+
+    windowManager.removeFromWindow(window2);
+
+    expect(windowManager.getLatestWindow()).toBeUndefined();
+  });
+});

--- a/src/content/services/index.ts
+++ b/src/content/services/index.ts
@@ -6,3 +6,4 @@ export { EventManager } from './event-manager';
 export { PreferencePaneManager } from './preference-pane-manager';
 export { SyncManager } from './sync-manager';
 export { UIManager } from './ui-manager';
+export { WindowManager } from './window-manager';

--- a/src/content/services/service.ts
+++ b/src/content/services/service.ts
@@ -1,9 +1,11 @@
 import type { PluginInfo } from '../plugin-info';
 
 import type { EventManager } from './event-manager';
+import type { WindowManager } from './window-manager';
 
 type Dependencies = {
   eventManager: EventManager;
+  windowManager: WindowManager;
 };
 
 export type ServiceParams = {

--- a/src/content/services/window-manager.ts
+++ b/src/content/services/window-manager.ts
@@ -1,0 +1,24 @@
+import type { Service } from './service';
+
+export class WindowManager implements Service {
+  private readonly windows: Zotero.ZoteroWindow[] = [];
+
+  public startup() {}
+
+  public addToWindow(window: Zotero.ZoteroWindow) {
+    if (!this.windows.includes(window)) {
+      this.windows.unshift(window);
+    }
+  }
+
+  public removeFromWindow(window: Zotero.ZoteroWindow) {
+    const index = this.windows.indexOf(window);
+    if (index >= 0) {
+      this.windows.splice(index, 1);
+    }
+  }
+
+  public getLatestWindow(): Zotero.ZoteroWindow | undefined {
+    return this.windows[0];
+  }
+}

--- a/src/content/sync/__tests__/property-builder.spec.ts
+++ b/src/content/sync/__tests__/property-builder.spec.ts
@@ -4,9 +4,9 @@ import { createZoteroCollectionMock, zoteroMock } from '../../../../test/utils';
 import { PageTitleFormat } from '../../prefs/notero-pref';
 import { getItemURL, keyValue } from '../../utils';
 import type {
-  DatabasePageProperties,
   DatabaseProperties,
   DatabasePropertyConfig,
+  DatabaseRequestProperties,
 } from '../notion-types';
 import { buildProperties } from '../property-builder';
 
@@ -215,7 +215,7 @@ describe('buildProperties', () => {
       pageTitleFormat: PageTitleFormat.itemTitle,
     });
 
-    const expected: DatabasePageProperties = {
+    const expected: DatabaseRequestProperties = {
       title: {
         title: [{ text: { content: fakeTitle } }],
       },
@@ -255,7 +255,7 @@ describe('buildProperties', () => {
       pageTitleFormat: PageTitleFormat.itemTitle,
     });
 
-    const expected: DatabasePageProperties = {
+    const expected: DatabaseRequestProperties = {
       title: {
         title: [{ text: { content: fakeTitle } }],
       },
@@ -278,7 +278,7 @@ describe('buildProperties', () => {
       pageTitleFormat: PageTitleFormat.itemTitle,
     });
 
-    const expected: DatabasePageProperties = {
+    const expected: DatabaseRequestProperties = {
       title: {
         title: [{ text: { content: fakeTitle } }],
       },

--- a/src/content/sync/__tests__/property-builder.spec.ts
+++ b/src/content/sync/__tests__/property-builder.spec.ts
@@ -1,9 +1,6 @@
 import { any, mock } from 'jest-mock-extended';
 
-import {
-  createZoteroCollectionMock,
-  zoteroMock,
-} from '../../../../test/utils/zotero-mock';
+import { createZoteroCollectionMock, zoteroMock } from '../../../../test/utils';
 import { PageTitleFormat } from '../../prefs/notero-pref';
 import { getItemURL, keyValue } from '../../utils';
 import type {

--- a/src/content/sync/find-duplicates.ts
+++ b/src/content/sync/find-duplicates.ts
@@ -2,36 +2,90 @@ import { collectPaginatedAPI, type Client, isFullPage } from '@notionhq/client';
 
 import { NoteroPref, getRequiredNoteroPref } from '../prefs/notero-pref';
 
-import { isPropertyOfType } from './notion-types';
+import {
+  PropertyResponse,
+  ResponsePropertyType,
+  isPropertyOfType,
+} from './notion-types';
 
-export async function findDuplicates(notion: Client): Promise<Set<string>> {
+const VALID_PROPERTY_TYPES = [
+  'rich_text',
+  'title',
+  'url',
+] satisfies ResponsePropertyType[];
+
+type ValidPropertyType = (typeof VALID_PROPERTY_TYPES)[number];
+
+const isValidProperty = isPropertyOfType(VALID_PROPERTY_TYPES);
+
+export async function findDuplicates(
+  notion: Client,
+  propertyName: string,
+): Promise<Set<string>> {
   const databaseID = getRequiredNoteroPref(NoteroPref.notionDatabaseID);
+
+  const propertyID = await getPropertyID(notion, databaseID, propertyName);
 
   const pages = await collectPaginatedAPI(notion.databases.query, {
     database_id: databaseID,
-    filter_properties: ['title'],
-    sorts: [{ direction: 'ascending', property: 'title' }],
+    filter_properties: [propertyID],
+    sorts: [{ direction: 'ascending', property: propertyName }],
   });
 
-  const titles = new Set<string>();
+  const comparisonValues = new Set<string>();
   const duplicates = new Set<string>();
 
   for (const page of pages) {
     if (!isFullPage(page)) continue;
 
-    const titleProperty = Object.values(page.properties).find(
-      isPropertyOfType('title'),
-    );
-    if (!titleProperty) continue;
+    const property = Object.values(page.properties)
+      .filter(isValidProperty)
+      .find(({ id }) => id === propertyID);
+    if (!property) continue;
 
-    const title = titleProperty.title.map((t) => t.plain_text).join('');
+    const textValue = getPropertyTextValue(property);
+    if (!textValue) continue;
 
-    if (titles.has(title)) {
-      duplicates.add(title);
+    if (comparisonValues.has(textValue)) {
+      duplicates.add(textValue);
     } else {
-      titles.add(title);
+      comparisonValues.add(textValue);
     }
   }
 
   return duplicates;
+}
+
+async function getPropertyID(
+  notion: Client,
+  databaseID: string,
+  propertyName: string,
+): Promise<string> {
+  if (propertyName === 'title') return 'title';
+
+  const database = await notion.databases.retrieve({ database_id: databaseID });
+
+  const property = database.properties[propertyName];
+
+  if (!property) {
+    throw new Error(`Could not find property "${propertyName}"`);
+  }
+  if (!VALID_PROPERTY_TYPES.includes(property.type)) {
+    throw new Error(
+      `Property "${propertyName}" has invalid type "${property.type}"`,
+    );
+  }
+
+  return property.id;
+}
+
+function getPropertyTextValue(
+  property: PropertyResponse<ValidPropertyType>,
+): string | null {
+  if (property.type === 'url') return property.url;
+
+  const richText =
+    property.type === 'rich_text' ? property.rich_text : property.title;
+
+  return richText.map((t) => t.plain_text).join('');
 }

--- a/src/content/sync/find-duplicates.ts
+++ b/src/content/sync/find-duplicates.ts
@@ -1,0 +1,37 @@
+import { collectPaginatedAPI, type Client, isFullPage } from '@notionhq/client';
+
+import { NoteroPref, getRequiredNoteroPref } from '../prefs/notero-pref';
+
+import { isPropertyOfType } from './notion-types';
+
+export async function findDuplicates(notion: Client): Promise<Set<string>> {
+  const databaseID = getRequiredNoteroPref(NoteroPref.notionDatabaseID);
+
+  const pages = await collectPaginatedAPI(notion.databases.query, {
+    database_id: databaseID,
+    filter_properties: ['title'],
+    sorts: [{ direction: 'ascending', property: 'title' }],
+  });
+
+  const titles = new Set<string>();
+  const duplicates = new Set<string>();
+
+  for (const page of pages) {
+    if (!isFullPage(page)) continue;
+
+    const titleProperty = Object.values(page.properties).find(
+      isPropertyOfType('title'),
+    );
+    if (!titleProperty) continue;
+
+    const title = titleProperty.title.map((t) => t.plain_text).join('');
+
+    if (titles.has(title)) {
+      duplicates.add(title);
+    } else {
+      titles.add(title);
+    }
+  }
+
+  return duplicates;
+}

--- a/src/content/sync/notion-client.ts
+++ b/src/content/sync/notion-client.ts
@@ -1,7 +1,7 @@
 import { Client, Logger, LogLevel } from '@notionhq/client';
 
-import { getNoteroPref, NoteroPref } from '../prefs/notero-pref';
-import { getLocalizedString, log } from '../utils';
+import { getRequiredNoteroPref, NoteroPref } from '../prefs/notero-pref';
+import { log } from '../utils';
 
 const logger: Logger = (level, message, extraInfo) => {
   log(
@@ -11,11 +11,7 @@ const logger: Logger = (level, message, extraInfo) => {
 };
 
 export function getNotionClient(window: Window) {
-  const authToken = getNoteroPref(NoteroPref.notionToken);
-
-  if (!authToken) {
-    throw new Error(`Missing ${getLocalizedString(NoteroPref.notionToken)}`);
-  }
+  const authToken = getRequiredNoteroPref(NoteroPref.notionToken);
 
   return new Client({
     auth: authToken,

--- a/src/content/sync/notion-types.ts
+++ b/src/content/sync/notion-types.ts
@@ -101,3 +101,20 @@ export type PropertyRequest<T extends RequestPropertyType> = Extract<
   DatabaseRequestProperty,
   { [P in T]: unknown }
 >[T];
+
+/// Pages ///
+
+type PageResponseProperty = PageObjectResponse['properties'][string];
+
+type ResponsePropertyType = PageResponseProperty['type'];
+
+type PropertyResponse<T extends ResponsePropertyType> = Extract<
+  PageResponseProperty,
+  { type: T }
+>;
+
+export function isPropertyOfType<T extends ResponsePropertyType>(type: T) {
+  return (
+    property: PropertyResponse<ResponsePropertyType>,
+  ): property is PropertyResponse<T> => property.type === type;
+}

--- a/src/content/sync/notion-types.ts
+++ b/src/content/sync/notion-types.ts
@@ -104,17 +104,16 @@ export type PropertyRequest<T extends RequestPropertyType> = Extract<
 
 /// Pages ///
 
-type PageResponseProperty = PageObjectResponse['properties'][string];
+export type PageResponseProperty = PageObjectResponse['properties'][string];
 
-type ResponsePropertyType = PageResponseProperty['type'];
+export type ResponsePropertyType = PageResponseProperty['type'];
 
-type PropertyResponse<T extends ResponsePropertyType> = Extract<
+export type PropertyResponse<T extends ResponsePropertyType> = Extract<
   PageResponseProperty,
   { type: T }
 >;
 
-export function isPropertyOfType<T extends ResponsePropertyType>(type: T) {
-  return (
-    property: PropertyResponse<ResponsePropertyType>,
-  ): property is PropertyResponse<T> => property.type === type;
+export function isPropertyOfType<T extends ResponsePropertyType>(type: T[]) {
+  return (property: PageResponseProperty): property is PropertyResponse<T> =>
+    (type as ResponsePropertyType[]).includes(property.type);
 }

--- a/src/content/sync/notion-types.ts
+++ b/src/content/sync/notion-types.ts
@@ -1,7 +1,8 @@
 import type {
   BlockObjectRequest,
   CreatePageParameters,
-  GetDatabaseResponse,
+  DatabaseObjectResponse,
+  PageObjectResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 
 /// Blocks ///
@@ -80,23 +81,23 @@ export function isBlockType<T extends BlockType>(
 
 /// Databases ///
 
-export type DatabaseProperties = GetDatabaseResponse['properties'];
+export type DatabaseProperties = DatabaseObjectResponse['properties'];
 
-export type DatabasePropertyConfig<T extends PropertyType> = Extract<
+export type DatabasePropertyConfig<T extends RequestPropertyType> = Extract<
   DatabaseProperties[string],
   { type: T }
 >;
 
-export type DatabasePageProperties = CreatePageParameters['properties'];
+export type DatabaseRequestProperties = CreatePageParameters['properties'];
 
-export type DatabasePageProperty = Extract<
-  DatabasePageProperties[string],
+export type DatabaseRequestProperty = Extract<
+  DatabaseRequestProperties[string],
   { type?: string }
 >;
 
-export type PropertyType = NonNullable<DatabasePageProperty['type']>;
+export type RequestPropertyType = NonNullable<DatabaseRequestProperty['type']>;
 
-export type PropertyRequest<T extends PropertyType> = Extract<
-  DatabasePageProperty,
+export type PropertyRequest<T extends RequestPropertyType> = Extract<
+  DatabaseRequestProperty,
   { [P in T]: unknown }
 >[T];

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -3,11 +3,11 @@ import { PageTitleFormat } from '../prefs/notero-pref';
 import { buildCollectionFullName, getItemURL, parseItemDate } from '../utils';
 
 import type {
-  DatabasePageProperties,
-  DatabasePageProperty,
   DatabaseProperties,
+  DatabaseRequestProperties,
+  DatabaseRequestProperty,
   PropertyRequest,
-  PropertyType,
+  RequestPropertyType,
 } from './notion-types';
 import { buildDate, buildRichText } from './notion-utils';
 
@@ -18,7 +18,7 @@ type PropertyBuilderParams = {
   pageTitleFormat: PageTitleFormat;
 };
 
-type PropertyDefinition<T extends PropertyType = PropertyType> = {
+type PropertyDefinition<T extends RequestPropertyType = RequestPropertyType> = {
   [P in T]: {
     name: string;
     type: P;
@@ -28,7 +28,7 @@ type PropertyDefinition<T extends PropertyType = PropertyType> = {
 
 export function buildProperties(
   params: PropertyBuilderParams,
-): Promise<DatabasePageProperties> {
+): Promise<DatabaseRequestProperties> {
   const propertyBuilder = new PropertyBuilder(params);
   return propertyBuilder.buildProperties();
 }
@@ -56,8 +56,8 @@ class PropertyBuilder {
     this.pageTitleFormat = params.pageTitleFormat;
   }
 
-  public async buildProperties(): Promise<DatabasePageProperties> {
-    const properties: DatabasePageProperties = {
+  public async buildProperties(): Promise<DatabaseRequestProperties> {
+    const properties: DatabaseRequestProperties = {
       title: {
         title: buildRichText(await this.getPageTitle()),
       },
@@ -73,7 +73,7 @@ class PropertyBuilder {
       properties[name] = {
         type,
         [type]: request,
-      } as DatabasePageProperty;
+      } as DatabaseRequestProperty;
     }
 
     return properties;

--- a/src/content/sync/sync-job.ts
+++ b/src/content/sync/sync-job.ts
@@ -14,8 +14,9 @@ import {
   NoteroPref,
   PageTitleFormat,
   getNoteroPref,
+  getRequiredNoteroPref,
 } from '../prefs/notero-pref';
-import { getLocalizedString, hasErrorStack, log } from '../utils';
+import { hasErrorStack, log } from '../utils';
 
 import { getNotionClient } from './notion-client';
 import type { DatabaseProperties } from './notion-types';
@@ -67,7 +68,7 @@ async function prepareSyncJob({
   window: Window;
 }): Promise<SyncJob> {
   const notion = getNotionClient(window);
-  const databaseID = getDatabaseID();
+  const databaseID = getRequiredNoteroPref(NoteroPref.notionDatabaseID);
   const databaseProperties = await retrieveDatabaseProperties(
     notion,
     databaseID,
@@ -92,14 +93,6 @@ function getCitationFormat(): string {
   if (typeof format === 'string' && format) return format;
 
   return APA_STYLE;
-}
-
-function getDatabaseID(): string {
-  const databaseID = getNoteroPref(NoteroPref.notionDatabaseID);
-
-  if (databaseID) return databaseID;
-
-  throw new Error(`Missing ${getLocalizedString(NoteroPref.notionDatabaseID)}`);
 }
 
 function getPageTitleFormat(): PageTitleFormat {

--- a/src/content/utils/__tests__/build-collection-full-name.spec.ts
+++ b/src/content/utils/__tests__/build-collection-full-name.spec.ts
@@ -1,4 +1,4 @@
-import { createZoteroCollectionMock } from '../../../../test/utils/zotero-mock';
+import { createZoteroCollectionMock } from '../../../../test/utils';
 import { buildCollectionFullName } from '../build-collection-full-name';
 
 const parent = createZoteroCollectionMock({ name: 'Parent Name' });

--- a/src/content/utils/__tests__/get-item-url.spec.ts
+++ b/src/content/utils/__tests__/get-item-url.spec.ts
@@ -1,7 +1,4 @@
-import {
-  createZoteroItemMock,
-  zoteroMock,
-} from '../../../../test/utils/zotero-mock';
+import { createZoteroItemMock, zoteroMock } from '../../../../test/utils';
 import { getItemURL } from '../get-item-url';
 
 const itemMock = createZoteroItemMock();

--- a/src/content/utils/create-html-element.ts
+++ b/src/content/utils/create-html-element.ts
@@ -1,8 +1,0 @@
-const HTML_NS = 'http://www.w3.org/1999/xhtml';
-
-export function createHTMLElement<Name extends keyof HTMLElementTagNameMap>(
-  doc: Document,
-  name: Name,
-) {
-  return doc.createElementNS(HTML_NS, name) as HTMLElementTagNameMap[Name];
-}

--- a/src/content/utils/create-xul-element.ts
+++ b/src/content/utils/create-xul-element.ts
@@ -1,8 +1,0 @@
-const XUL_NS = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
-
-export function createXULElement<Name extends keyof XUL.XULElementTagNameMap>(
-  doc: Document,
-  name: Name,
-) {
-  return doc.createElementNS(XUL_NS, name) as XUL.XULElementTagNameMap[Name];
-}

--- a/src/content/utils/elements.ts
+++ b/src/content/utils/elements.ts
@@ -15,6 +15,8 @@ export function createXULElement<Name extends keyof XUL.XULElementTagNameMap>(
   return doc.createElementNS(XUL_NS, name) as XUL.XULElementTagNameMap[Name];
 }
 
-export function getXULElementById<E extends XUL.XULElement>(id: string): E {
-  return document.getElementById(id) as unknown as E;
+export function getXULElementById<E extends XUL.XULElement>(
+  id: string,
+): E | null {
+  return document.getElementById(id) as E | null;
 }

--- a/src/content/utils/elements.ts
+++ b/src/content/utils/elements.ts
@@ -1,0 +1,20 @@
+const HTML_NS = 'http://www.w3.org/1999/xhtml';
+const XUL_NS = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
+
+export function createHTMLElement<Name extends keyof HTMLElementTagNameMap>(
+  doc: Document,
+  name: Name,
+) {
+  return doc.createElementNS(HTML_NS, name) as HTMLElementTagNameMap[Name];
+}
+
+export function createXULElement<Name extends keyof XUL.XULElementTagNameMap>(
+  doc: Document,
+  name: Name,
+) {
+  return doc.createElementNS(XUL_NS, name) as XUL.XULElementTagNameMap[Name];
+}
+
+export function getXULElementById<E extends XUL.XULElement>(id: string): E {
+  return document.getElementById(id) as unknown as E;
+}

--- a/src/content/utils/get-xul-element-by-id.ts
+++ b/src/content/utils/get-xul-element-by-id.ts
@@ -1,3 +1,0 @@
-export function getXULElementById<E extends XUL.XULElement>(id: string): E {
-  return document.getElementById(id) as unknown as E;
-}

--- a/src/content/utils/index.ts
+++ b/src/content/utils/index.ts
@@ -1,12 +1,14 @@
 export { buildCollectionFullName } from './build-collection-full-name';
 export { chunkString } from './chunk-string';
-export { createHTMLElement } from './create-html-element';
-export { createXULElement } from './create-xul-element';
+export {
+  createHTMLElement,
+  createXULElement,
+  getXULElementById,
+} from './elements';
 export { getAllCollectionItems } from './get-all-collection-items';
 export { getDOMParser } from './get-dom-parser';
 export { getItemURL } from './get-item-url';
 export { getLocalizedString } from './get-localized-string';
-export { getXULElementById } from './get-xul-element-by-id';
 export { hasErrorStack } from './has-error-stack';
 export { isObject } from './is-object';
 export { keyValue } from './key-value';

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,0 +1,7 @@
+export { createWindowMock } from './window-mock';
+export {
+  createZoteroCollectionMock,
+  createZoteroItemMock,
+  mockZoteroPrefs,
+  zoteroMock,
+} from './zotero-mock';

--- a/test/utils/window-mock.ts
+++ b/test/utils/window-mock.ts
@@ -1,0 +1,6 @@
+import { JSDOM } from 'jsdom';
+
+export function createWindowMock(): Zotero.ZoteroWindow {
+  const dom = new JSDOM();
+  return dom.window as unknown as Zotero.ZoteroWindow;
+}


### PR DESCRIPTION
## Summary

Depending on the circumstances, Notero can sometimes end up creating duplicate Notion pages for a given Zotero item. To address this issue as requested in #252, this PR adds a utility function for finding duplicate pages based on a specific database property.

There is no UI created for this utility yet. This is a first iteration to test the efficacy of this approach based on user feedback.

## Usage

The utility function can be called via the **Run JavaScript** window available from the menu: **Tools → Developer → Run JavaScript**.

Paste the following code into the window, ensure the "Run as async function" option is enabled, and click the **Run** button at the top left. This will return page titles that appear in the database multiple times.

```js
return await Zotero.Notero.findDuplicates();
```

To find duplicates based on a different database property, pass the property name to the `findDuplicates` function. For example, to find duplicates with the same `Zotero URI`, use the following code.

```js
return await Zotero.Notero.findDuplicates('Zotero URI');
```

You can then use the results to search for the duplicate pages in Notion.

## Example

https://github.com/dvanoni/notero/assets/299357/3676cc7b-7298-4f24-b2ef-ee0ae9b52ae4
