### PR TITLE
ci: Fix release tagging and versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": false,
       "draft": false,
       "prerelease": false
     }


### PR DESCRIPTION
- Disable [`include-component-in-tag`](https://github.com/googleapis/release-please/blob/f78f87b3ec986344c9265a9bd225b92a41aeac23/docs/manifest-releaser.md#subsequent-versions) option for Release Please so that it doesn't prefix releases with `notero`
- Update `version.ts` script so that it doesn't publish release artifacts with a prerelease version