### PR TITLE
fix: Restore preferences menu item in Zotero 7

### DIFF
--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -22,18 +22,21 @@ if (!IS_ZOTERO_7) {
 
 export class Notero {
   private readonly eventManager: EventManager;
+  private readonly preferencePaneManager: PreferencePaneManager;
   private readonly windowManager: WindowManager;
   private readonly services: Service[];
 
   public constructor() {
     this.eventManager = new EventManager();
+    this.preferencePaneManager = new PreferencePaneManager();
     this.windowManager = new WindowManager();
 
     this.services = [
       ...(IS_ZOTERO_7
-        ? [new ChromeManager(), new PreferencePaneManager()]
+        ? [new ChromeManager()]
         : [new DefaultPreferencesLoader()]),
       this.eventManager,
+      this.preferencePaneManager,
       this.windowManager,
       new SyncManager(),
       new UIManager(),
@@ -55,6 +58,7 @@ export class Notero {
   private async startServices(pluginInfo: PluginInfo) {
     const dependencies = {
       eventManager: this.eventManager,
+      preferencePaneManager: this.preferencePaneManager,
       windowManager: this.windowManager,
     };
 

--- a/src/content/notero.ts
+++ b/src/content/notero.ts
@@ -14,7 +14,7 @@ import {
 } from './services';
 import { findDuplicates } from './sync/find-duplicates';
 import { getNotionClient } from './sync/notion-client';
-import { log } from './utils';
+import { hasErrorStack, log } from './utils';
 
 if (!IS_ZOTERO_7) {
   Cu.importGlobalProperties(['URL']);
@@ -43,7 +43,7 @@ export class Notero {
   public async startup(pluginInfo: PluginInfo) {
     await Zotero.uiReadyPromise;
 
-    this.startServices(pluginInfo);
+    await this.startServices(pluginInfo);
     this.addToAllWindows();
   }
 
@@ -52,16 +52,22 @@ export class Notero {
     this.shutDownServices();
   }
 
-  private startServices(pluginInfo: PluginInfo) {
+  private async startServices(pluginInfo: PluginInfo) {
     const dependencies = {
       eventManager: this.eventManager,
       windowManager: this.windowManager,
     };
 
-    this.services.forEach((service) => {
-      log(`Starting ${service.constructor.name}`);
-      service.startup({ dependencies, pluginInfo });
-    });
+    for (const service of this.services) {
+      const serviceName = service.constructor.name;
+      try {
+        log(`Starting ${serviceName}`);
+        await service.startup({ dependencies, pluginInfo });
+      } catch (error) {
+        log(`Failed to start ${serviceName}: ${String(error)}`, 'error');
+        if (hasErrorStack(error)) log(error.stack, 'error');
+      }
+    }
   }
 
   private shutDownServices() {

--- a/src/content/services/preference-pane-manager.ts
+++ b/src/content/services/preference-pane-manager.ts
@@ -1,13 +1,30 @@
+import { IS_ZOTERO_7 } from '../constants';
+
 import type { Service, ServiceParams } from './service';
 
 export class PreferencePaneManager implements Service {
-  public startup({ pluginInfo: { pluginID, rootURI } }: ServiceParams) {
-    void Zotero.PreferencePanes.register({
+  private paneID?: string;
+
+  public async startup({ pluginInfo: { pluginID, rootURI } }: ServiceParams) {
+    if (!IS_ZOTERO_7) return;
+
+    this.paneID = await Zotero.PreferencePanes.register({
       pluginID,
       src: rootURI + 'content/prefs/preferences.xhtml',
       scripts: [rootURI + 'content/prefs/preferences.js'],
       stylesheets: [rootURI + 'content/style/preferences.css'],
       helpURL: 'https://github.com/dvanoni/notero#readme',
     });
+  }
+
+  public openPreferences(window: Zotero.ZoteroWindow) {
+    if (IS_ZOTERO_7) {
+      Zotero.Utilities.Internal.openPreferences(this.paneID);
+    } else {
+      window.openDialog(
+        'chrome://notero/content/prefs/preferences.xul',
+        'notero-preferences',
+      );
+    }
   }
 }

--- a/src/content/services/service.ts
+++ b/src/content/services/service.ts
@@ -1,10 +1,10 @@
 import type { PluginInfo } from '../plugin-info';
 
-import type { EventManager } from './event-manager';
-import type { WindowManager } from './window-manager';
+import type { EventManager, PreferencePaneManager, WindowManager } from '.';
 
 type Dependencies = {
   eventManager: EventManager;
+  preferencePaneManager: PreferencePaneManager;
   windowManager: WindowManager;
 };
 

--- a/src/content/services/service.ts
+++ b/src/content/services/service.ts
@@ -8,8 +8,8 @@ type Dependencies = {
   windowManager: WindowManager;
 };
 
-export type ServiceParams = {
-  dependencies: Dependencies;
+export type ServiceParams<D extends keyof Dependencies = never> = {
+  dependencies: Pick<Dependencies, D>;
   pluginInfo: PluginInfo;
 };
 

--- a/src/content/services/service.ts
+++ b/src/content/services/service.ts
@@ -14,7 +14,7 @@ export type ServiceParams = {
 };
 
 export interface Service {
-  startup(params: ServiceParams): void;
+  startup(params: ServiceParams): void | Promise<void>;
   shutdown?(): void;
   addToWindow?(window: Zotero.ZoteroWindow): void;
   removeFromWindow?(window: Zotero.ZoteroWindow): void;

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -24,12 +24,12 @@ export class SyncManager implements Service {
   private syncInProgress = false;
 
   public startup({
-    dependencies: { eventManager, windowManager },
-  }: ServiceParams) {
-    this.eventManager = eventManager;
-    this.windowManager = windowManager;
+    dependencies,
+  }: ServiceParams<'eventManager' | 'windowManager'>) {
+    this.eventManager = dependencies.eventManager;
+    this.windowManager = dependencies.windowManager;
 
-    const { addListener } = eventManager;
+    const { addListener } = this.eventManager;
 
     addListener('notifier-event', this.handleNotifierEvent);
     addListener('request-sync-collection', this.handleSyncCollection);

--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -10,7 +10,9 @@ export class UIManager implements Service {
 
   private managedWindows = new Map<Zotero.ZoteroWindow, Set<Node>>();
 
-  public startup({ dependencies }: ServiceParams) {
+  public startup({
+    dependencies,
+  }: ServiceParams<'eventManager' | 'preferencePaneManager'>) {
     this.eventManager = dependencies.eventManager;
     this.preferencePaneManager = dependencies.preferencePaneManager;
   }

--- a/src/content/services/ui-manager.ts
+++ b/src/content/services/ui-manager.ts
@@ -1,22 +1,24 @@
-import { IS_ZOTERO_7 } from '../constants';
 import { createXULElement, getLocalizedString, log } from '../utils';
 
 import type { EventManager } from './event-manager';
+import type { PreferencePaneManager } from './preference-pane-manager';
 import type { Service, ServiceParams } from './service';
 
 export class UIManager implements Service {
   private eventManager!: EventManager;
+  private preferencePaneManager!: PreferencePaneManager;
 
   private managedWindows = new Map<Zotero.ZoteroWindow, Set<Node>>();
 
-  public startup({ dependencies: { eventManager } }: ServiceParams) {
-    this.eventManager = eventManager;
+  public startup({ dependencies }: ServiceParams) {
+    this.eventManager = dependencies.eventManager;
+    this.preferencePaneManager = dependencies.preferencePaneManager;
   }
 
   public addToWindow(window: Zotero.ZoteroWindow) {
     this.initCollectionMenuItem(window);
     this.initItemMenuItem(window);
-    if (!IS_ZOTERO_7) this.initToolsMenuItem(window);
+    this.initToolsMenuItem(window);
   }
 
   public removeFromWindow(window: Zotero.ZoteroWindow) {
@@ -68,7 +70,7 @@ export class UIManager implements Service {
       labelName: 'notero.toolsMenu.preferences',
       parentId: 'menu_ToolsPopup',
       onCommand: () => {
-        this.openPreferences(window);
+        this.preferencePaneManager.openPreferences(window);
       },
     });
   }
@@ -98,12 +100,5 @@ export class UIManager implements Service {
     this.addManagedNode(window, menuItem);
 
     return menuItem;
-  }
-
-  private openPreferences(window: Zotero.ZoteroWindow) {
-    window.openDialog(
-      'chrome://notero/content/prefs/preferences.xul',
-      'notero-preferences',
-    );
   }
 }

--- a/types/zotero.d.ts
+++ b/types/zotero.d.ts
@@ -433,6 +433,17 @@ declare namespace Zotero {
     getCurrentUsername(): string | undefined;
   }
 
+  interface UtilitiesInternal {
+    openPreferences(
+      paneID?: string,
+      options?: {
+        action?: string;
+        tab?: string;
+        tabIndex?: number;
+      },
+    ): XPCOM.nsIDOMWindow | null;
+  }
+
   interface ZoteroPane {
     document: Document;
 
@@ -466,6 +477,7 @@ declare interface Zotero {
   QuickCopy: Zotero.QuickCopy;
   URI: Zotero.URI;
   Users: Zotero.Users;
+  Utilities: { Internal: Zotero.UtilitiesInternal };
 
   /** Display an alert in a given window */
   alert(window: Window, title: string, msg: string): void;


### PR DESCRIPTION
In Zotero 7 the preferences for Notero have moved into a pane in the main Zotero preferences window. However, as described in #395 and #432, this isn't clear at all.

To address this, we're restoring the **Notero Preferences...** item to the **Tools** menu in Zotero 7. Clicking it opens the Zotero preferences window and activates the Notero pane.

Closes #432