### PR TITLE
chore(CHANGELOG): Fix compare link for v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Restore preferences menu item in Zotero 7 ([#440](https://github.com/dvanoni/notero/issues/440)) ([35cf3cd](https://github.com/dvanoni/notero/commit/35cf3cdddffa0589d9209260894f1a7d8c9764fd)), closes [#432](https://github.com/dvanoni/notero/issues/432)
 
-## [0.5.8](https://github.com/dvanoni/notero/compare/notero-v0.5.7...notero-v0.5.8) (2024-01-15)
+## [0.5.8](https://github.com/dvanoni/notero/compare/v0.5.7...v0.5.8) (2024-01-15)
 
 
 ### Features


### PR DESCRIPTION
The link got messed up in #436 by my initial attempt at configuring Release Please