### PR TITLE
fix: Require minimum Zotero version 6.0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "id": "notero@vanoni.dev",
     "name": "Notero",
     "releaseURL": "https://github.com/dvanoni/notero/releases/download/release/",
-    "supportsZotero7": true
+    "supportsZotero7": true,
+    "zoteroMinVersion": "6.0.27"
   },
   "dependencies": {
     "@notionhq/client": "^2.2.14",

--- a/scripts/generate-install-manifest.ts
+++ b/scripts/generate-install-manifest.ts
@@ -23,6 +23,7 @@ const installRdfVars = {
   name: pkg.xpi.name,
   updateURL: `${pkg.xpi.releaseURL}update.rdf`,
   version,
+  zoteroMinVersion: pkg.xpi.zoteroMinVersion,
 };
 
 const template = fs.readFileSync(

--- a/scripts/install.rdf.pug
+++ b/scripts/install.rdf.pug
@@ -27,7 +27,3 @@ RDF(xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.moz
         em:id zotero@chnm.gmu.edu
         em:minVersion #{zotero || '5.0.79'}
         em:maxVersion 6.0.*
-      Description
-        em:id juris-m@juris-m.github.io
-        em:minVersion #{jurism || '5.0.79'}
-        em:maxVersion 6.0.*

--- a/scripts/install.rdf.pug
+++ b/scripts/install.rdf.pug
@@ -25,5 +25,5 @@ RDF(xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.moz
     em:targetApplication
       Description
         em:id zotero@chnm.gmu.edu
-        em:minVersion #{zotero || '5.0.79'}
+        em:minVersion= zoteroMinVersion
         em:maxVersion 6.0.*


### PR DESCRIPTION
## Summary

Require a minimum Zotero version of 6.0.27 and stop supporting Juris-M.

## Details

With #340 we started relying on the new `Zotero.getMainWindows()` function that was added to Zotero in zotero/zotero@fb148497ba8abc338e0916f33297330ce8657270 and released in version [6.0.27](https://github.com/zotero/zotero/releases/tag/6.0.27), meaning that Notero versions [0.4.13](https://github.com/dvanoni/notero/releases/tag/v0.4.13) and above require a minimum Zotero version of 6.0.27.

This change caused issues for users who were on newer versions of Notero but not Zotero, as described in these issues:

- https://github.com/dvanoni/notero/issues/147#issuecomment-1747527674
- #331
- #348
- #445