### PR TITLE
feat: Show title of item when failing to sync

### DIFF
--- a/src/content/sync/progress-window.ts
+++ b/src/content/sync/progress-window.ts
@@ -11,10 +11,13 @@ export class ProgressWindow {
     this.itemCount = itemCount;
 
     this.progressWindow = new Zotero.ProgressWindow();
-    this.progressWindow.changeHeadline('Syncing items to Notion...');
+    this.progressWindow.changeHeadline(
+      'Syncing items to Notion...',
+      NOTION_LOGO,
+    );
     this.progressWindow.show();
 
-    this.itemProgress = new this.progressWindow.ItemProgress(NOTION_LOGO, '');
+    this.itemProgress = new this.progressWindow.ItemProgress('', '');
   }
 
   public updateText(step: number) {
@@ -31,8 +34,18 @@ export class ProgressWindow {
     this.progressWindow.startCloseTimer();
   }
 
-  public fail(errorMessage: string) {
-    this.itemProgress.setError();
-    this.progressWindow.addDescription(errorMessage);
+  public fail(errorMessage: string, failedItem?: Zotero.Item) {
+    if (failedItem) {
+      new this.progressWindow.ItemProgress(
+        Zotero.ItemTypes.getImageSrc(failedItem.itemType),
+        failedItem.getDisplayTitle(),
+        this.itemProgress,
+      ).setProgress(100);
+      new this.progressWindow.ItemProgress('', errorMessage).setError();
+    } else {
+      this.itemProgress.setError();
+      this.itemProgress.setText(errorMessage);
+      this.progressWindow.addDescription(''); // Hack to force window resize
+    }
   }
 }

--- a/types/zotero.d.ts
+++ b/types/zotero.d.ts
@@ -210,6 +210,7 @@ declare namespace Zotero {
   }
 
   interface ItemTypes extends CachedTypes {
+    getImageSrc(itemType: string): string;
     getLocalizedString(idOrName: number | string): string;
   }
 


### PR DESCRIPTION
To help with fixing sync errors, we now show the title of the item that is failing to sync.

Closes #377

| Before | After |
|--------|--------|
| ![CleanShot 2024-01-23 at 23 47 01@2x](https://github.com/dvanoni/notero/assets/299357/37c34051-ea15-4ee2-ade6-aa5e7839c58e) | ![CleanShot 2024-01-23 at 23 49 33@2x](https://github.com/dvanoni/notero/assets/299357/c3befd96-964b-4b20-ada6-63091cf5339b) | 