### PR TITLE
fix: Ensure newly-added items sync even if not modified

### DIFF
--- a/src/content/services/__tests__/sync-manager.spec.ts
+++ b/src/content/services/__tests__/sync-manager.spec.ts
@@ -346,6 +346,48 @@ describe('SyncManager', () => {
     });
   });
 
+  describe('receiving `collection-item.add` notifier event', () => {
+    it('does not perform sync when item is not in sync-enabled collection', () => {
+      const { eventManager } = setup();
+
+      eventManager.emit('notifier-event', 'collection-item.add', [
+        [1234, regularItemNotInCollection.id],
+      ]);
+
+      jest.runAllTimers();
+
+      expect(performSyncJob).toHaveBeenCalledTimes(0);
+    });
+
+    it('syncs item and notes when `syncOnModifyItems` is disabled and item is in sync-enabled collection', () => {
+      const { eventManager } = setup({ syncOnModifyItems: false });
+
+      eventManager.emit('notifier-event', 'collection-item.add', [
+        [collection.id, regularItem.id],
+      ]);
+
+      jest.runAllTimers();
+
+      expect(mockedPerformSyncJob.mock.lastCall?.[0]).toStrictEqual(
+        new Set([regularItem.id, outOfSyncNoteItem.id, unsyncedNoteItem.id]),
+      );
+    });
+
+    it('syncs item when `syncOnModifyItems` is enabled and item is in sync-enabled collection', () => {
+      const { eventManager } = setup({ syncOnModifyItems: true });
+
+      eventManager.emit('notifier-event', 'collection-item.add', [
+        [collection.id, regularItem.id],
+      ]);
+
+      jest.runAllTimers();
+
+      expect(mockedPerformSyncJob.mock.lastCall?.[0]).toStrictEqual(
+        new Set([regularItem.id, outOfSyncNoteItem.id, unsyncedNoteItem.id]),
+      );
+    });
+  });
+
   describe('receiving `item.modify` notifier event', () => {
     it('does not perform sync when `syncOnModifyItems` is disabled', () => {
       const { eventManager } = setup({ syncOnModifyItems: false });

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -106,12 +106,7 @@ export class SyncManager implements Service {
   ): Zotero.Item[] {
     const syncOnModifyItems = getNoteroPref(NoteroPref.syncOnModifyItems);
 
-    if (!syncOnModifyItems) {
-      if (event === 'collection-item.add') {
-        const items = Zotero.Items.get(this.getIndexedIDs(1, ids));
-        const notes = this.getNotesToSync(items);
-        return items.concat(notes);
-      }
+    if (!syncOnModifyItems && event !== 'collection-item.add') {
       return [];
     }
 
@@ -119,6 +114,11 @@ export class SyncManager implements Service {
       case 'collection.delete':
       case 'collection.modify':
         return this.getItemsFromCollectionIDs(ids);
+      case 'collection-item.add': {
+        const items = Zotero.Items.get(this.getIndexedIDs(1, ids));
+        const notes = this.getNotesToSync(items);
+        return items.concat(notes);
+      }
       case 'item.modify': {
         const items = Zotero.Items.get(ids);
         const notes = this.getNotesToSync(items);

--- a/src/content/sync/sync-job.ts
+++ b/src/content/sync/sync-job.ts
@@ -152,7 +152,7 @@ class SyncJob {
   public async perform() {
     for (const [index, item] of this.items.entries()) {
       const step = index + 1;
-      log(`Saving item ${step} of ${this.items.length} with ID ${item.id}`);
+      log(`Syncing item ${step} of ${this.items.length} with ID ${item.id}`);
 
       this.progressWindow.updateText(step);
 


### PR DESCRIPTION
Fixes #269

## Problem

When the "sync when items are modified" option was enabled, Notero would only sync items when they were modified (`modify item` event) and _not_ when they were added to a collection (`add collection-item` event). This would usually work fine because when a user manually moves an item into a collection, it triggers both the `add collection-item` and `modify item` events.

However, when items are added via the Zotero Connector browser extension, the `modify item` event is _not_ triggered by default. It appears to only trigger if Zotero Connector imports additional info or a PDF for the item. If Zotero Connector does not import anything additional, then only the `add collection-item` event is triggered. This meant that such items would not automatically sync upon import.

## Solution

To fix this issue, items are always synced when the `add collection-item` event is triggered.

A potential downside of this approach is that syncing may be triggered multiple times depending on how long it takes Zotero Connector to import additional info. Specifically, additional syncs will occur if the time between the initial `add collection-item` event and subsequent imports (`modify item` events) is greater than the sync debounce delay ([currently 2 seconds](https://github.com/dvanoni/notero/blob/dbaa85f0a43af2063b5884d16c2cfe9e86291fab/src/content/services/sync-manager.ts#L11)).