### PR TITLE
fix: Fix sync configs table not rendering all items until scroll

### DIFF
--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -54,6 +54,9 @@ class Preferences {
     this.notionDatabaseError = getXULElementById('notero-notionDatabaseError')!;
     this.notionDatabaseMenu = getXULElementById('notero-notionDatabase')!;
     this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat')!;
+    const syncConfigsTableContainer = document.getElementById(
+      'notero-syncConfigsTable-container',
+    )!;
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     this.prefObserverSymbol = registerNoteroPrefObserver(
@@ -75,8 +78,8 @@ class Preferences {
     }, 100);
 
     ReactDOM.render(
-      <SyncConfigsTable />,
-      document.getElementById('notero-syncConfigsTable-container'),
+      <SyncConfigsTable container={syncConfigsTableContainer} />,
+      syncConfigsTableContainer,
     );
   }
 


### PR DESCRIPTION
Fixes #412

In Zotero 7, the sync configs table would not render all items until it was scrolled. To resolve this, we now force the table to re-render once it becomes visible within the window (using [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)).

Somewhat inspired by [this fix in Zotero](https://github.com/zotero/zotero/blob/ee9e11a3ebd464f9482c27447c641692d9e2ea12/chrome/content/zotero/preferences/preferences_cite.jsx#L128).