### PR TITLE
fix: Only convert html links if they use http or https protocol

### DIFF
--- a/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/index.ts
@@ -6,6 +6,7 @@ import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 import * as annotations from './annotations';
 import * as blockquote from './blockquote';
 import * as formatting from './formatting';
+import * as links from './links';
 import * as nestedStyles from './nestedStyles';
 import * as simple from './simple';
 import * as textOnly from './textOnly';
@@ -21,6 +22,7 @@ const cases: Record<string, Pick<NoteTestCase, 'expected'>> = {
   annotations,
   blockquote,
   formatting,
+  links,
   nestedStyles,
   simple,
   textOnly,

--- a/src/content/sync/html-to-notion/__tests__/fixtures/links.html
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/links.html
@@ -1,0 +1,3 @@
+<a href="https://notion.so">https link</a>
+<a href="http://notion.so">http link</a>
+<a href="zotero://select/item">zotero link</a>

--- a/src/content/sync/html-to-notion/__tests__/fixtures/links.ts
+++ b/src/content/sync/html-to-notion/__tests__/fixtures/links.ts
@@ -1,0 +1,19 @@
+import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+
+export const expected: BlockObjectRequest[] = [
+  {
+    paragraph: {
+      rich_text: [
+        {
+          text: { content: 'https link', link: { url: 'https://notion.so/' } },
+        },
+        { text: { content: ' ' } },
+        {
+          text: { content: 'http link', link: { url: 'http://notion.so/' } },
+        },
+        { text: { content: ' ' } },
+        { text: { content: 'zotero link' } },
+      ],
+    },
+  },
+];

--- a/src/content/sync/html-to-notion/parse-node.ts
+++ b/src/content/sync/html-to-notion/parse-node.ts
@@ -95,9 +95,11 @@ function getMathExpression(element: HTMLElement): string | null {
 }
 
 function parseAnchorElement(element: HTMLAnchorElement): RichTextElement {
+  const isHttpURL = /^https?:\/\/.+/.test(element.href);
+
   return {
     ...parseRichTextElement(element),
-    link: { url: element.href },
+    ...(isHttpURL && { link: { url: element.href } }),
   };
 }
 


### PR DESCRIPTION
Fixes #458

## Problem

Notion only supports links that use the `http:` or `https:` protocol. This would cause an error when trying to sync notes with other types of links such as `zotero:`.

## Solution

To resolve this, the `link` part of a rich text object is now only included if the link uses `http:` or `https:`.