### PR TITLE
refactor: Use esbuild `inject` to shim timer functions

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,16 +1,5 @@
 import esbuild, { BuildOptions } from 'esbuild';
 
-const banner = `if (!Zotero.Notero) {
-
-// Make timer functions globally available in Zotero 6
-if (typeof setTimeout === 'undefined') {
-  var setTimeout = Zotero.setTimeout;
-}
-if (typeof clearTimeout === 'undefined') {
-  var clearTimeout = Zotero.clearTimeout;
-}
-`;
-
 const builds: (BuildOptions & { entryPoints: [string] })[] = [
   {
     entryPoints: ['src/bootstrap.ts'],
@@ -23,9 +12,8 @@ const builds: (BuildOptions & { entryPoints: [string] })[] = [
     format: 'iife',
     target: ['firefox60'],
     entryPoints: ['src/content/notero.ts'],
+    inject: ['src/shims/timer.ts'],
     outdir: 'build/content',
-    banner: { js: banner },
-    footer: { js: '\n}' },
   },
   {
     bundle: true,

--- a/src/shims/timer.ts
+++ b/src/shims/timer.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+// Use esbuild `inject` to make timer functions globally available in Zotero 6
+
+const setTimeoutShim =
+  typeof setTimeout !== 'undefined' ? setTimeout : Zotero.setTimeout;
+
+const clearTimeoutShim =
+  typeof clearTimeout !== 'undefined' ? clearTimeout : Zotero.clearTimeout;
+
+export { setTimeoutShim as setTimeout, clearTimeoutShim as clearTimeout };


### PR DESCRIPTION
Shimming the timer functions in the `banner` content of the build bundle always felt pretty hacky. Now we use [`inject`](https://esbuild.github.io/api/#inject) to add the shims in a more structured manner.

This PR also remove the wrapping `if (!Zotero.Notero) { /* entire bundle here */ }` block which didn't seem necessary any more.