### PR TITLE
fix: Avoid creating duplicate note blocks in Notion

### DIFF
--- a/src/content/data/item-data.ts
+++ b/src/content/data/item-data.ts
@@ -5,7 +5,7 @@ import { getDOMParser, isObject } from '../utils';
 
 const SYNCED_NOTES_ID = 'notero-synced-notes';
 
-type SyncedNotes = {
+export type SyncedNotes = {
   containerBlockID?: string;
   notes?: {
     [noteItemKey: Zotero.DataObjectKey]: {
@@ -128,7 +128,7 @@ export function getSyncedNotesFromAttachment(
 export async function saveSyncedNote(
   item: Zotero.Item,
   containerBlockID: string,
-  noteBlockID: string,
+  noteBlockID: string | undefined,
   noteItemKey: Zotero.DataObjectKey,
 ) {
   const attachment = getNotionLinkAttachment(item);
@@ -140,10 +140,12 @@ export async function saveSyncedNote(
     containerBlockID,
     notes: {
       ...notes,
-      [noteItemKey]: {
-        blockID: noteBlockID,
-        syncedAt: new Date(),
-      },
+      ...(noteBlockID && {
+        [noteItemKey]: {
+          blockID: noteBlockID,
+          syncedAt: new Date(),
+        },
+      }),
     },
   };
 

--- a/src/content/sync/__tests__/sync-note.spec.ts
+++ b/src/content/sync/__tests__/sync-note.spec.ts
@@ -1,0 +1,170 @@
+import { APIErrorCode, APIResponseError, type Client } from '@notionhq/client';
+import {
+  PartialBlockObjectResponse,
+  type AppendBlockChildrenResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import { mockDeep, objectContainsValue } from 'jest-mock-extended';
+
+import { createZoteroItemMock } from '../../../../test/utils';
+import {
+  SyncedNotes,
+  getNotionPageID,
+  getSyncedNotes,
+  saveSyncedNote,
+} from '../../data/item-data';
+import { syncNote } from '../sync-note';
+
+jest.mock('../../data/item-data');
+
+const containerHeadingBlock = {
+  heading_1: {
+    rich_text: [{ text: { content: 'Zotero Notes' } }],
+    is_toggleable: true,
+  },
+};
+
+const objectNotFoundError = new APIResponseError({
+  code: APIErrorCode.ObjectNotFound,
+  status: 404,
+  message: 'Not found',
+  headers: {},
+  rawBodyText: 'Not found',
+});
+
+const fakeNoteTitle = 'Fake Note Title';
+const fakePageID = 'fake-page-id';
+const fakeContainerID = 'fake-container-id';
+const fakeNoteBlockID = 'fake-note-block-id';
+
+function createResponseMock(response: Partial<PartialBlockObjectResponse>) {
+  return mockDeep<AppendBlockChildrenResponse>({
+    results: [{ object: 'block', id: 'id', ...response }],
+  });
+}
+
+function setup({ syncedNotes }: { syncedNotes: SyncedNotes }) {
+  jest.clearAllMocks();
+
+  const noteItem = createZoteroItemMock({
+    getNoteTitle: () => fakeNoteTitle,
+  });
+  const notion = mockDeep<Client>({
+    fallbackMockImplementation: () => {
+      throw new Error('NOT MOCKED');
+    },
+  });
+  const regularItem = createZoteroItemMock();
+  noteItem.topLevelItem = regularItem;
+
+  jest.mocked(getNotionPageID).mockReturnValue(fakePageID);
+  jest.mocked(getSyncedNotes).mockReturnValue(syncedNotes);
+
+  notion.blocks.children.append
+    .calledWith(objectContainsValue(fakePageID))
+    .mockResolvedValue(createResponseMock({ id: fakeContainerID }));
+  notion.blocks.children.append
+    .calledWith(objectContainsValue(fakeContainerID))
+    .mockResolvedValue(createResponseMock({ id: fakeNoteBlockID }));
+  notion.blocks.children.append
+    .calledWith(objectContainsValue(fakeNoteBlockID))
+    .mockResolvedValue(createResponseMock({}));
+
+  return { noteItem, notion, regularItem };
+}
+
+describe('syncNote', () => {
+  it('creates a container block when item does not already have one', async () => {
+    const { noteItem, notion } = setup({ syncedNotes: {} });
+
+    await syncNote(notion, noteItem);
+
+    expect(notion.blocks.children.append).toHaveBeenCalledWith({
+      block_id: fakePageID,
+      children: [containerHeadingBlock],
+    });
+  });
+
+  it('saves the containerBlockID to the regular item', async () => {
+    const { noteItem, notion, regularItem } = setup({ syncedNotes: {} });
+
+    await syncNote(notion, noteItem);
+
+    expect(saveSyncedNote).toHaveBeenCalledWith(
+      regularItem,
+      fakeContainerID,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  describe('when item has a containerBlockID', () => {
+    it('does not create a container block if existing one is found', async () => {
+      const { noteItem, notion } = setup({
+        syncedNotes: { containerBlockID: fakeContainerID },
+      });
+
+      await syncNote(notion, noteItem);
+
+      expect(notion.blocks.children.append).not.toHaveBeenCalledWith({
+        block_id: fakePageID,
+        children: [containerHeadingBlock],
+      });
+    });
+
+    it('creates a new container block if existing one is not found', async () => {
+      const { noteItem, notion } = setup({
+        syncedNotes: { containerBlockID: fakeContainerID },
+      });
+
+      notion.blocks.children.append
+        .calledWith(objectContainsValue(fakeContainerID))
+        .mockRejectedValueOnce(objectNotFoundError)
+        .mockResolvedValueOnce(createResponseMock({ id: fakeNoteBlockID }));
+
+      await syncNote(notion, noteItem);
+
+      expect(notion.blocks.children.append).toHaveBeenCalledWith({
+        block_id: fakePageID,
+        children: [containerHeadingBlock],
+      });
+    });
+  });
+
+  it('saves container block ID even when note block fails to create', async () => {
+    const { noteItem, notion, regularItem } = setup({
+      syncedNotes: { containerBlockID: fakeContainerID },
+    });
+
+    notion.blocks.children.append
+      .calledWith(objectContainsValue(fakeContainerID))
+      .mockRejectedValue(new Error('Failed to append children'));
+
+    await expect(() => syncNote(notion, noteItem)).rejects.toThrow();
+
+    expect(saveSyncedNote).toHaveBeenCalledWith(
+      regularItem,
+      fakeContainerID,
+      undefined,
+      expect.anything(),
+    );
+  });
+
+  it('saves note block ID even when note content fails to sync', async () => {
+    const { noteItem, notion, regularItem } = setup({
+      syncedNotes: { containerBlockID: fakeContainerID },
+    });
+
+    notion.blocks.children.append
+      .calledWith(objectContainsValue(fakeNoteBlockID))
+      .mockRejectedValue(new Error('Failed to append children'));
+
+    await expect(() => syncNote(notion, noteItem)).rejects.toThrow();
+
+    expect(saveSyncedNote).toHaveBeenCalledWith(
+      regularItem,
+      expect.anything(),
+      fakeNoteBlockID,
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

As reported in #463, duplicate "Zotero Notes" blocks end up created when note content fails to sync. This occurred because block IDs were not saved into Zotero when a note failed to sync—even though the container blocks (i.e. "Zotero Notes" and the note heading) were indeed created in Notion. Without saving the block IDs into Zotero, the next sync attempt had nothing to reference and thus created additional container blocks.

## Solution

We now save block IDs before attempting to sync the note content so that, if the note content fails to sync, we've already saved references to the block IDs to be used for the next sync attempt. Additionally, if we successfully create the "Zotero Notes" container but fail to create the note heading container, we still save the block ID of the "Zotero Notes" container.