### PR TITLE
ci: Use GitHub App token to run `release-please` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,20 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: {}
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - id: release-please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
   publish-artifacts:
     needs: release-please
     if: needs.release-please.outputs.release_created


### PR DESCRIPTION
GitHub Actions has a [limitation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) where a workflow run using the default `GITHUB_TOKEN` will not trigger further workflow runs. This was impacting the `release-please` job because the release PRs created by it would not trigger the `build` job. This unfortunately led me to disable the build check for PRs to `main`, which was not ideal.

Educated by [documentation for the create-pull-request action](https://github.com/peter-evans/create-pull-request/blob/ce008085c89860856de52c613ad894311f83c931/docs/concepts-guidelines.md#triggering-further-workflow-runs), I found a workaround for this using GitHub Apps and created the [Notero Bot](https://github.com/apps/notero-bot) app for this purpose. The `release-please` job now uses the [create-github-app-token](https://github.com/actions/create-github-app-token) action to create a token on behalf of Notero Bot and use that for creating the release PRs. This should hopefully result in workflows being run for these PRs, which will then allow us to re-enable the PR checks.

This PR also replaces `google-github-actions/release-please-action` with `googleapis/release-please-action` since it was [recently moved](https://github.com/google-github-actions/release-please-action/pull/1).