### PR TITLE
fix(notes): Improve handling of deleted note blocks

### DIFF
--- a/src/content/sync/notion-utils/__tests__/error.spec.ts
+++ b/src/content/sync/notion-utils/__tests__/error.spec.ts
@@ -2,7 +2,7 @@ import { APIErrorCode } from '@notionhq/client';
 import { APIResponseError } from '@notionhq/client/build/src/errors';
 import { mock } from 'jest-mock-extended';
 
-import { isNotionErrorWithCode } from '../error';
+import { isArchivedOrNotFoundError, isNotionErrorWithCode } from '../error';
 
 describe('isNotionErrorWithCode', () => {
   it('returns false for generic error', () => {
@@ -39,5 +39,50 @@ describe('isNotionErrorWithCode', () => {
     expect(isNotionErrorWithCode(error, APIErrorCode.ObjectNotFound)).toBe(
       true,
     );
+  });
+});
+
+describe('isArchivedOrNotFoundError', () => {
+  it('returns false for generic error', () => {
+    const error = new Error('Generic error');
+
+    expect(isArchivedOrNotFoundError(error)).toBe(false);
+  });
+
+  it('returns false for other API errors', () => {
+    const error = new APIResponseError({
+      code: APIErrorCode.InternalServerError,
+      headers: mock<APIResponseError['headers']>(),
+      message: 'Fake error',
+      rawBodyText: 'Fake error',
+      status: 500,
+    });
+
+    expect(isArchivedOrNotFoundError(error)).toBe(false);
+  });
+
+  it('returns true for not found error', () => {
+    const error = new APIResponseError({
+      code: APIErrorCode.ObjectNotFound,
+      headers: mock<APIResponseError['headers']>(),
+      message: 'Fake error',
+      rawBodyText: 'Fake error',
+      status: 404,
+    });
+
+    expect(isArchivedOrNotFoundError(error)).toBe(true);
+  });
+
+  it('returns true for archived error', () => {
+    const error = new APIResponseError({
+      code: APIErrorCode.ValidationError,
+      headers: mock<APIResponseError['headers']>(),
+      message:
+        "Can't edit page on block with an archived ancestor. You must unarchive the ancestor before editing page.",
+      rawBodyText: 'Fake error',
+      status: 400,
+    });
+
+    expect(isArchivedOrNotFoundError(error)).toBe(true);
   });
 });

--- a/src/content/sync/notion-utils/error.ts
+++ b/src/content/sync/notion-utils/error.ts
@@ -1,4 +1,5 @@
 import {
+  APIErrorCode,
   NotionClientError,
   NotionErrorCode,
   isNotionClientError,
@@ -9,4 +10,16 @@ export function isNotionErrorWithCode<Code extends NotionErrorCode>(
   code: Code,
 ): error is NotionClientError & { code: Code } {
   return isNotionClientError(error) && error.code === code;
+}
+
+export function isArchivedOrNotFoundError(
+  error: unknown,
+): error is NotionClientError & {
+  code: APIErrorCode.ObjectNotFound | APIErrorCode.ValidationError;
+} {
+  return (
+    isNotionErrorWithCode(error, APIErrorCode.ObjectNotFound) ||
+    (isNotionErrorWithCode(error, APIErrorCode.ValidationError) &&
+      error.message.includes('archive'))
+  );
 }

--- a/src/content/sync/notion-utils/index.ts
+++ b/src/content/sync/notion-utils/index.ts
@@ -1,4 +1,4 @@
 export { buildDate } from './build-date';
 export { buildRichText } from './build-rich-text';
-export { isNotionErrorWithCode } from './error';
+export { isArchivedOrNotFoundError, isNotionErrorWithCode } from './error';
 export { convertWebURLToAppURL, getPageIDFromURL, isNotionURL } from './url';


### PR DESCRIPTION
When syncing notes into a container block that had been deleted, it appears the Notion API could return either a "not found" error or a validation error with a message about the block being "archived." This fix attempts to handle both cases whereas we previously only handled the "not found" case.