### PR TITLE
build: Use built-in dev tools when starting Zotero 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ documentation and should allow you to build and run Notero yourself.
     5.  Start Zotero with the profile specified in `zotero.config.json` and the
         following command line arguments:
 
-            -purgecaches -ZoteroDebugText -jsconsole -debugger -datadir profile
+            -purgecaches -ZoteroDebugText -jsdebugger -datadir profile
 
     6.  If defined, run the `scripts.poststart` command specified in
-        `zotero.config.json`.
+        `zotero.config.json`, providing it with a `ZOTERO_PID` environment variable.
 
 [generator-zotero-plugin]: https://github.com/retorquere/generator-zotero-plugin
 [zotero-plugin]: https://github.com/retorquere/zotero-plugin

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -105,11 +105,15 @@ function getZoteroArgs(): string[] {
   const zoteroArgs = [
     '-purgecaches',
     '-ZoteroDebugText',
-    '-jsconsole',
-    '-debugger',
     '-datadir',
     'profile',
   ];
+
+  if (isBetaRun) {
+    zoteroArgs.push('-jsdebugger');
+  } else {
+    zoteroArgs.push('-jsconsole', '-debugger');
+  }
 
   if (config.profile?.name) {
     zoteroArgs.push('-p', config.profile.name);
@@ -122,7 +126,7 @@ function getZoteroPath(): string {
   if (isBetaRun) {
     assert.ok(
       config.zotero?.betaPath && fs.existsSync(config.zotero.betaPath),
-      new Error('Invalid path to Zotero beta'),
+      'Invalid path to Zotero beta',
     );
     return config.zotero.betaPath;
   }

--- a/zotero.config.example.json
+++ b/zotero.config.example.json
@@ -10,7 +10,7 @@
     // (optional) Command to run before Zotero starts.
     "prestart": "pkill zotero",
     // (optional) Command to run after Zotero starts.
-    "poststart": "sleep 2 && osascript -e 'tell app \"Zotero\" to activate'"
+    "poststart": "sleep 3 && osascript -e \"tell application \\\"System Events\\\" to set frontmost of first application process whose unix id is $ZOTERO_PID to true\""
   },
   "zotero": {
     // (optional) Explicit path to executable for your default Zotero version.


### PR DESCRIPTION
It was recently [mentioned in the zotero-dev list](https://groups.google.com/g/zotero-dev/c/h4_UZDml-10/m/gDIzOtPkAAAJ) that the `-jsdebugger` flag can be passed when starting Zotero 7 to open the built-in developer tools, eliminating the need to have to connect from Firefox.

This PR updates the `start` script to use this `-jsdebugger` flag when starting Zotero 7 while maintaining the `-jsconsole` and `-debugger` flags for Zotero 6.

The `start` script also now provides a `ZOTERO_PID` environment variable to the `poststart` script which can be used for more effectively bringing Zotero to the foreground on macOS. `zotero.config.example.json` is updated to show how to use this.