### PR TITLE
build: Remove `npx` from Husky hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+commitlint --edit $1


### PR DESCRIPTION
Husky [v9.1.1](https://github.com/typicode/husky/releases/tag/v9.1.1) added the ability to run npm package commands directly without using `npx`. So, this PR removes usage of `npx` from Husky hooks.