### PR TITLE
fix: Improve generation of author-date page titles

### DIFF
--- a/src/content/sync/__tests__/property-builder.spec.ts
+++ b/src/content/sync/__tests__/property-builder.spec.ts
@@ -158,6 +158,7 @@ function setup() {
   item.getField.calledWith('abstractNote').mockReturnValue(fakeAbstract);
   item.getField.calledWith('citationKey').mockReturnValue(fakeCitationKey);
   item.getField.calledWith('date').mockReturnValue(fakeDate);
+  item.getField.calledWith('firstCreator').mockReturnValue(fakeLastName1);
   item.getField.calledWith('shortTitle').mockReturnValue(fakeShortTitle);
   item.getField.calledWith('year').mockReturnValue(String(fakeYear));
   item.getTags.mockReturnValue([{ tag: fakeTag, type: 1 }]);

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -1,4 +1,4 @@
-import { APA_STYLE, NOTION_TAG_NAME } from '../constants';
+import { NOTION_TAG_NAME } from '../constants';
 import { PageTitleFormat } from '../prefs/notero-pref';
 import {
   buildCollectionFullName,
@@ -116,9 +116,14 @@ class PropertyBuilder {
     return pageTitle || this.getTitle();
   }
 
-  private async getAuthorDateCitation(): Promise<string | null> {
-    const citation = await this.getCachedCitation(APA_STYLE, true);
-    return citation?.match(/^\((.+)\)$/)?.[1] || null;
+  private getAuthorDateCitation(): string {
+    let citation =
+      this.item.getField('firstCreator') || this.item.getDisplayTitle();
+    let date = this.item.getField('date', true, true);
+    if (date && (date = date.substring(0, 4)) !== '0000') {
+      citation += ', ' + date;
+    }
+    return citation;
   }
 
   private getCitationKey(): string | undefined {


### PR DESCRIPTION
Instead of using the APA style to generate author-date citation page titles, we now generate the citation by directly using a combination of the `firstCreator`, `displayTitle`, and `date` fields—inspired by the [`_buildBubbleString`](https://github.com/zotero/zotero/blob/181196149aea0b652ee938aaff7e1c0c217f0a2e/chrome/content/zotero/integration/quickFormat.js#L1070) function in Zotero.

This provides a couple benefits:

- We no longer require the APA style to be installed. This should hopefully resolve the `TypeError: style.getCiteProc is not a function` issue that many folks have reported.
   - Closes #12
   - Closes #543
- We now avoid the performance impact of generating citations with APA style. See more details in [this Zotero forum post](https://forums.zotero.org/discussion/113721/zotero-7-beta-time-delay-when-doing-a-drag-and-drop-of-an-item).
   - Closes #457


