### PR TITLE
ci: Skip release comments for PRs labeled `autorelease` or `maintenance`

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          skip-label: 'autorelease: tagged,dependencies,maintenance'


### PR DESCRIPTION
Using `skip-label` input from [github-release-commenter](https://github.com/apexskier/github-release-commenter)