### PR TITLE
fix(sync): Support changing destination Notion database

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -2,9 +2,9 @@
 [
   {
     "label": "Build",
-    "command": "npm",
+    "command": "npm run build",
     // rest of the parameters are optional
-    "args": ["run", "build"],
+    // "args": [],
     // Env overrides for the command, will be appended to the terminal's environment from the settings.
     // "env": { "foo": "bar" },
     // Current working directory to spawn the command into, defaults to current project root.
@@ -20,49 +20,45 @@
   },
   {
     "label": "Build with source maps",
-    "command": "npm",
-    "args": ["run", "build", "--", "--sourcemap"],
+    "command": "npm run build -- --sourcemap",
     "reveal": "never"
   },
   {
     "label": "Generate Fluent types",
-    "command": "npm",
-    "args": ["run", "generate-fluent-types"],
+    "command": "npm run generate-fluent-types",
     "reveal": "never"
   },
   {
     "label": "Start Zotero",
-    "command": "npm",
-    "args": ["run", "start"],
+    "command": "npm run start",
     "reveal": "never"
   },
   {
     "label": "Start Zotero Beta",
-    "command": "npm",
-    "args": ["run", "start:beta"],
+    "command": "npm run start:beta",
     "reveal": "never"
   },
   {
     "label": "Test all (once)",
-    "command": "npm",
-    "args": ["run", "test"],
+    "command": "npm run test",
     "reveal": "always"
   },
   {
     "label": "Test all (watch)",
-    "command": "npm",
-    "args": ["run", "test:watch"],
+    "command": "npm run test:watch",
     "reveal": "always"
   },
   {
     "label": "Test $ZED_STEM",
     "command": "npx vitest related",
-    "args": ["\"$ZED_RELATIVE_FILE\""]
+    "args": ["\"$ZED_RELATIVE_FILE\""],
+    "reveal": "always"
   },
   {
     "label": "Test $ZED_SYMBOL",
     "command": "npx vitest",
     "args": ["\"$ZED_RELATIVE_FILE\"", "--testNamePattern", "\"$ZED_SYMBOL\""],
+    "reveal": "always",
     "tags": ["ts-test", "tsx-test"]
   }
 ]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -43,15 +43,26 @@
     "reveal": "never"
   },
   {
-    "label": "Test",
+    "label": "Test all (once)",
     "command": "npm",
     "args": ["run", "test"],
     "reveal": "always"
   },
   {
-    "label": "Test watch",
+    "label": "Test all (watch)",
     "command": "npm",
     "args": ["run", "test:watch"],
     "reveal": "always"
+  },
+  {
+    "label": "Test $ZED_STEM",
+    "command": "npx vitest related",
+    "args": ["\"$ZED_RELATIVE_FILE\""]
+  },
+  {
+    "label": "Test $ZED_SYMBOL",
+    "command": "npx vitest",
+    "args": ["\"$ZED_RELATIVE_FILE\"", "--testNamePattern", "\"$ZED_SYMBOL\""],
+    "tags": ["ts-test", "tsx-test"]
   }
 ]

--- a/src/content/data/__tests__/item-data.spec.ts
+++ b/src/content/data/__tests__/item-data.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { createZoteroItemMock } from '../../../../test/utils';
-import { getSyncedNotesFromAttachment } from '../item-data';
+import { createZoteroItemMock, mockZoteroPrefs } from '../../../../test/utils';
+import { NoteroPref, setNoteroPref } from '../../prefs/notero-pref';
+import {
+  getSyncedNotesFromAttachment,
+  saveNotionLinkAttachment,
+} from '../item-data';
 
 describe('getSyncedNotesFromAttachment', () => {
   it('loads expected data when synced notes are saved in original format', () => {
@@ -48,5 +52,51 @@ describe('getSyncedNotesFromAttachment', () => {
         keyB: { blockID: 'blockB', syncedAt: dateB },
       },
     });
+  });
+});
+
+describe('saveNotionLinkAttachment', () => {
+  it('preserves synced notes when page ID does not change', async () => {
+    mockZoteroPrefs();
+    setNoteroPref(NoteroPref.syncNotes, true);
+    const pageURL =
+      'notion://www.notion.so/page-00000000000000000000000000000000';
+    const syncedNotes =
+      '<pre id="notero-synced-notes">{"existing":"notes"}</pre>';
+    const item = createZoteroItemMock();
+    const attachment = createZoteroItemMock();
+    item.getAttachments.mockReturnValue([attachment.id]);
+    attachment.getField.calledWith('url').mockReturnValue(pageURL);
+    attachment.getNote.mockReturnValue(syncedNotes);
+
+    await saveNotionLinkAttachment(item, pageURL);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(attachment.setNote).toHaveBeenCalledWith(
+      expect.stringContaining(syncedNotes),
+    );
+  });
+
+  it('resets synced notes when page ID changes', async () => {
+    mockZoteroPrefs();
+    setNoteroPref(NoteroPref.syncNotes, true);
+    const oldPageURL =
+      'notion://www.notion.so/old-page-00000000000000000000000000000000';
+    const newPageURL =
+      'notion://www.notion.so/new-page-77777777777777777777777777777777';
+    const syncedNotes =
+      '<pre id="notero-synced-notes">{"existing":"notes"}</pre>';
+    const item = createZoteroItemMock();
+    const attachment = createZoteroItemMock();
+    item.getAttachments.mockReturnValue([attachment.id]);
+    attachment.getField.calledWith('url').mockReturnValue(oldPageURL);
+    attachment.getNote.mockReturnValue(syncedNotes);
+
+    await saveNotionLinkAttachment(item, newPageURL);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(attachment.setNote).toHaveBeenCalledWith(
+      expect.stringContaining('<pre id="notero-synced-notes">{}</pre>'),
+    );
   });
 });

--- a/src/content/errors/ItemSyncError.ts
+++ b/src/content/errors/ItemSyncError.ts
@@ -1,0 +1,11 @@
+export class ItemSyncError extends Error {
+  public readonly item: Zotero.Item;
+  public readonly name = 'ItemSyncError';
+
+  public constructor(cause: unknown, item: Zotero.Item) {
+    super(`Failed to sync item with ID ${item.id} due to ${String(cause)}`, {
+      cause,
+    });
+    this.item = item;
+  }
+}

--- a/src/content/errors/index.ts
+++ b/src/content/errors/index.ts
@@ -1,2 +1,3 @@
+export { ItemSyncError } from './ItemSyncError';
 export { LocalizableError } from './LocalizableError';
 export { MissingPrefError } from './MissingPrefError';

--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -7,6 +7,7 @@ import type { createRoot } from 'react-dom/client';
 import { FluentMessageId } from '../../locale/fluent-types';
 import { LocalizableError } from '../errors';
 import { getNotionClient } from '../sync/notion-client';
+import { normalizeID } from '../sync/notion-utils';
 import {
   createXULElement,
   getLocalizedErrorMessage,
@@ -157,14 +158,13 @@ class Preferences {
       const databases = await this.retrieveNotionDatabases();
 
       menuItems = databases.map<MenuItem>((database) => {
-        const idWithoutDashes = database.id.replace(/-/g, '');
         const title = database.title.map((t) => t.plain_text).join('');
         const icon =
           database.icon?.type === 'emoji' ? database.icon.emoji : null;
 
         return {
           label: icon ? `${icon} ${title}` : title,
-          value: idWithoutDashes,
+          value: normalizeID(database.id),
         };
       });
 

--- a/src/content/sync/__tests__/sync-note-item.spec.ts
+++ b/src/content/sync/__tests__/sync-note-item.spec.ts
@@ -13,7 +13,7 @@ import {
   getSyncedNotes,
   saveSyncedNote,
 } from '../../data/item-data';
-import { syncNote } from '../sync-note';
+import { syncNoteItem } from '../sync-note-item';
 
 vi.mock('../../data/item-data');
 
@@ -74,13 +74,13 @@ function setup({ syncedNotes }: { syncedNotes: SyncedNotes }) {
   return { noteItem, notion, regularItem };
 }
 
-describe('syncNote', () => {
+describe('syncNoteItem', () => {
   it('throws an error when note has no parent', async () => {
     const { noteItem, notion } = setup({ syncedNotes: {} });
     noteItem.isTopLevelItem.mockReturnValue(true);
     noteItem.topLevelItem = noteItem;
 
-    await expect(syncNote(notion, noteItem)).rejects.toThrow(
+    await expect(() => syncNoteItem(noteItem, notion)).rejects.toThrow(
       'Cannot sync note without a parent item',
     );
   });
@@ -89,7 +89,7 @@ describe('syncNote', () => {
     const { noteItem, notion } = setup({ syncedNotes: {} });
     vi.mocked(getNotionPageID).mockReturnValue(undefined);
 
-    await expect(syncNote(notion, noteItem)).rejects.toThrow(
+    await expect(() => syncNoteItem(noteItem, notion)).rejects.toThrow(
       'Cannot sync note because its parent item is not synced',
     );
   });
@@ -97,7 +97,7 @@ describe('syncNote', () => {
   it('creates a container block when item does not already have one', async () => {
     const { noteItem, notion } = setup({ syncedNotes: {} });
 
-    await syncNote(notion, noteItem);
+    await syncNoteItem(notion, noteItem);
 
     expect(notion.blocks.children.append).toHaveBeenCalledWith({
       block_id: fakePageID,
@@ -108,7 +108,7 @@ describe('syncNote', () => {
   it('saves the containerBlockID to the regular item', async () => {
     const { noteItem, notion, regularItem } = setup({ syncedNotes: {} });
 
-    await syncNote(notion, noteItem);
+    await syncNoteItem(notion, noteItem);
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,
@@ -124,7 +124,7 @@ describe('syncNote', () => {
         syncedNotes: { containerBlockID: fakeContainerID },
       });
 
-      await syncNote(notion, noteItem);
+      await syncNoteItem(notion, noteItem);
 
       expect(notion.blocks.children.append).not.toHaveBeenCalledWith({
         block_id: fakePageID,
@@ -142,7 +142,7 @@ describe('syncNote', () => {
         .mockRejectedValueOnce(objectNotFoundError)
         .mockResolvedValueOnce(createResponseMock({ id: fakeNoteBlockID }));
 
-      await syncNote(notion, noteItem);
+      await syncNoteItem(notion, noteItem);
 
       expect(notion.blocks.children.append).toHaveBeenCalledWith({
         block_id: fakePageID,
@@ -160,7 +160,7 @@ describe('syncNote', () => {
       .calledWith(objectContainsValue(fakeContainerID))
       .mockRejectedValue(new Error('Failed to append children'));
 
-    await expect(() => syncNote(notion, noteItem)).rejects.toThrow();
+    await expect(() => syncNoteItem(notion, noteItem)).rejects.toThrow();
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,
@@ -179,7 +179,7 @@ describe('syncNote', () => {
       .calledWith(objectContainsValue(fakeNoteBlockID))
       .mockRejectedValue(new Error('Failed to append children'));
 
-    await expect(() => syncNote(notion, noteItem)).rejects.toThrow();
+    await expect(() => syncNoteItem(notion, noteItem)).rejects.toThrow();
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,

--- a/src/content/sync/__tests__/sync-note-item.spec.ts
+++ b/src/content/sync/__tests__/sync-note-item.spec.ts
@@ -1,7 +1,7 @@
 import { APIErrorCode, APIResponseError, type Client } from '@notionhq/client';
-import {
+import type {
+  AppendBlockChildrenResponse,
   PartialBlockObjectResponse,
-  type AppendBlockChildrenResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 import { describe, expect, it, vi } from 'vitest';
 import { mockDeep, objectContainsValue } from 'vitest-mock-extended';
@@ -97,7 +97,7 @@ describe('syncNoteItem', () => {
   it('creates a container block when item does not already have one', async () => {
     const { noteItem, notion } = setup({ syncedNotes: {} });
 
-    await syncNoteItem(notion, noteItem);
+    await syncNoteItem(noteItem, notion);
 
     expect(notion.blocks.children.append).toHaveBeenCalledWith({
       block_id: fakePageID,
@@ -108,7 +108,7 @@ describe('syncNoteItem', () => {
   it('saves the containerBlockID to the regular item', async () => {
     const { noteItem, notion, regularItem } = setup({ syncedNotes: {} });
 
-    await syncNoteItem(notion, noteItem);
+    await syncNoteItem(noteItem, notion);
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,
@@ -124,7 +124,7 @@ describe('syncNoteItem', () => {
         syncedNotes: { containerBlockID: fakeContainerID },
       });
 
-      await syncNoteItem(notion, noteItem);
+      await syncNoteItem(noteItem, notion);
 
       expect(notion.blocks.children.append).not.toHaveBeenCalledWith({
         block_id: fakePageID,
@@ -142,7 +142,7 @@ describe('syncNoteItem', () => {
         .mockRejectedValueOnce(objectNotFoundError)
         .mockResolvedValueOnce(createResponseMock({ id: fakeNoteBlockID }));
 
-      await syncNoteItem(notion, noteItem);
+      await syncNoteItem(noteItem, notion);
 
       expect(notion.blocks.children.append).toHaveBeenCalledWith({
         block_id: fakePageID,
@@ -160,7 +160,7 @@ describe('syncNoteItem', () => {
       .calledWith(objectContainsValue(fakeContainerID))
       .mockRejectedValue(new Error('Failed to append children'));
 
-    await expect(() => syncNoteItem(notion, noteItem)).rejects.toThrow();
+    await expect(() => syncNoteItem(noteItem, notion)).rejects.toThrow();
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,
@@ -179,7 +179,7 @@ describe('syncNoteItem', () => {
       .calledWith(objectContainsValue(fakeNoteBlockID))
       .mockRejectedValue(new Error('Failed to append children'));
 
-    await expect(() => syncNoteItem(notion, noteItem)).rejects.toThrow();
+    await expect(() => syncNoteItem(noteItem, notion)).rejects.toThrow();
 
     expect(saveSyncedNote).toHaveBeenCalledWith(
       regularItem,

--- a/src/content/sync/__tests__/sync-regular-item.spec.ts
+++ b/src/content/sync/__tests__/sync-regular-item.spec.ts
@@ -1,0 +1,186 @@
+import { APIErrorCode, APIResponseError, type Client } from '@notionhq/client';
+import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { describe, expect, it, vi } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { createZoteroItemMock } from '../../../../test/utils';
+import { getNotionPageID } from '../../data/item-data';
+import { PageTitleFormat } from '../../prefs/notero-pref';
+import type { DatabaseRequestProperties } from '../notion-types';
+import { buildProperties } from '../property-builder';
+import type { SyncJobParams } from '../sync-job';
+import { syncRegularItem } from '../sync-regular-item';
+
+vi.mock('../../data/item-data');
+vi.mock('../property-builder');
+
+const objectNotFoundError = new APIResponseError({
+  code: APIErrorCode.ObjectNotFound,
+  status: 404,
+  message: 'Not found',
+  headers: {},
+  rawBodyText: 'Not found',
+});
+
+const validationError = new APIResponseError({
+  code: APIErrorCode.ValidationError,
+  status: 400,
+  message: 'Validation error',
+  headers: {},
+  rawBodyText: 'Validation error',
+});
+
+const fakeCitationFormat = 'fake-style';
+const fakeDatabaseID = 'fake-database-id';
+const fakeDatabaseProperties = {};
+const fakePageID = 'fake-page-id';
+const fakePageProperties: DatabaseRequestProperties = { title: { title: [] } };
+const fakePageTitleFormat = PageTitleFormat.itemAuthorDateCitation;
+const fakePageResponse: PageObjectResponse = {
+  archived: false,
+  cover: null,
+  created_by: { id: '', object: 'user' },
+  created_time: '',
+  icon: null,
+  id: fakePageID,
+  in_trash: false,
+  last_edited_by: { id: '', object: 'user' },
+  last_edited_time: '',
+  object: 'page',
+  parent: { database_id: fakeDatabaseID, type: 'database_id' },
+  properties: {},
+  public_url: null,
+  url: 'fake-url',
+};
+
+function setup({ pageID }: { pageID?: string }) {
+  const regularItem = createZoteroItemMock();
+  const notion = mockDeep<Client>({
+    fallbackMockImplementation: () => {
+      throw new Error('NOT MOCKED');
+    },
+  });
+
+  vi.mocked(getNotionPageID).mockReturnValue(pageID);
+  vi.mocked(buildProperties).mockResolvedValue(fakePageProperties);
+
+  notion.pages.create.mockResolvedValue(fakePageResponse);
+  notion.pages.update.mockResolvedValue(fakePageResponse);
+  notion.pages.retrieve.mockResolvedValue(fakePageResponse);
+
+  const params: SyncJobParams = {
+    citationFormat: fakeCitationFormat,
+    databaseID: fakeDatabaseID,
+    databaseProperties: fakeDatabaseProperties,
+    notion,
+    pageTitleFormat: fakePageTitleFormat,
+  };
+
+  return { notion, params, regularItem };
+}
+
+describe('syncRegularItem', () => {
+  it('creates new page when page ID is not set', async () => {
+    const { notion, params, regularItem } = setup({ pageID: undefined });
+
+    await syncRegularItem(regularItem, params);
+
+    expect(notion.pages.create).toHaveBeenCalledWith({
+      parent: { database_id: fakeDatabaseID },
+      properties: fakePageProperties,
+    });
+    expect(notion.pages.update).not.toHaveBeenCalled();
+  });
+
+  it('updates existing page when page ID is set', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+
+    await syncRegularItem(regularItem, params);
+
+    expect(notion.pages.update).toHaveBeenCalledWith({
+      page_id: fakePageID,
+      properties: fakePageProperties,
+    });
+    expect(notion.pages.create).not.toHaveBeenCalled();
+  });
+
+  it('creates new page when existing page is not found', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+    notion.pages.update.mockRejectedValue(objectNotFoundError);
+
+    await syncRegularItem(regularItem, params);
+
+    expect(notion.pages.update).toHaveBeenCalledWith({
+      page_id: fakePageID,
+      properties: fakePageProperties,
+    });
+    expect(notion.pages.create).toHaveBeenCalledWith({
+      parent: { database_id: fakeDatabaseID },
+      properties: fakePageProperties,
+    });
+  });
+
+  it('creates new page when existing page belongs to different database', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+    notion.pages.update.mockResolvedValue({
+      ...fakePageResponse,
+      parent: { database_id: 'different-database-id', type: 'database_id' },
+    });
+
+    await syncRegularItem(regularItem, params);
+
+    expect(notion.pages.update).toHaveBeenCalledWith({
+      page_id: fakePageID,
+      properties: fakePageProperties,
+    });
+    expect(notion.pages.create).toHaveBeenCalledWith({
+      parent: { database_id: fakeDatabaseID },
+      properties: fakePageProperties,
+    });
+  });
+
+  it('creates new page when validation error is caused by differing database', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+    notion.pages.update.mockRejectedValue(validationError);
+    notion.pages.retrieve.mockResolvedValue({
+      ...fakePageResponse,
+      parent: { database_id: 'different-database-id', type: 'database_id' },
+    });
+
+    await syncRegularItem(regularItem, params);
+
+    expect(notion.pages.update).toHaveBeenCalledWith({
+      page_id: fakePageID,
+      properties: fakePageProperties,
+    });
+    expect(notion.pages.create).toHaveBeenCalledWith({
+      parent: { database_id: fakeDatabaseID },
+      properties: fakePageProperties,
+    });
+  });
+
+  it('throws error when validation error is not caused by differing database', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+    notion.pages.update.mockRejectedValue(validationError);
+
+    await expect(() => syncRegularItem(regularItem, params)).rejects.toThrow(
+      validationError,
+    );
+  });
+
+  it('throws error when error is unexpected type', async () => {
+    const { notion, params, regularItem } = setup({ pageID: fakePageID });
+    const unexpectedError = new APIResponseError({
+      code: APIErrorCode.InternalServerError,
+      status: 500,
+      message: 'Internal server error',
+      headers: {},
+      rawBodyText: 'Internal server error',
+    });
+    notion.pages.update.mockRejectedValue(unexpectedError);
+
+    await expect(() => syncRegularItem(regularItem, params)).rejects.toThrow(
+      unexpectedError,
+    );
+  });
+});

--- a/src/content/sync/notion-utils/index.ts
+++ b/src/content/sync/notion-utils/index.ts
@@ -1,4 +1,5 @@
 export { buildDate } from './build-date';
 export { buildRichText } from './build-rich-text';
 export { isArchivedOrNotFoundError, isNotionErrorWithCode } from './error';
+export { normalizeID } from './normalize-id';
 export { convertWebURLToAppURL, getPageIDFromURL, isNotionURL } from './url';

--- a/src/content/sync/notion-utils/normalize-id.ts
+++ b/src/content/sync/notion-utils/normalize-id.ts
@@ -1,0 +1,3 @@
+export function normalizeID(id: string): string {
+  return id.replace(/-/g, '');
+}

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -17,7 +17,7 @@ import type {
 } from './notion-types';
 import { buildDate, buildRichText } from './notion-utils';
 
-export type PropertyBuilderParams = {
+type PropertyBuilderParams = {
   citationFormat: string;
   databaseProperties: DatabaseProperties;
   item: Zotero.Item;

--- a/src/content/sync/property-builder.ts
+++ b/src/content/sync/property-builder.ts
@@ -17,7 +17,7 @@ import type {
 } from './notion-types';
 import { buildDate, buildRichText } from './notion-utils';
 
-type PropertyBuilderParams = {
+export type PropertyBuilderParams = {
   citationFormat: string;
   databaseProperties: DatabaseProperties;
   item: Zotero.Item;

--- a/src/content/sync/sync-job.ts
+++ b/src/content/sync/sync-job.ts
@@ -24,7 +24,7 @@ import type { DatabaseProperties } from './notion-types';
 import { convertWebURLToAppURL, isNotionErrorWithCode } from './notion-utils';
 import { ProgressWindow } from './progress-window';
 import { buildProperties } from './property-builder';
-import { syncNote } from './sync-note';
+import { syncNoteItem } from './sync-note-item';
 
 type SyncJobParams = {
   citationFormat: string;
@@ -227,6 +227,6 @@ class SyncJob {
   }
 
   private async syncNoteItem(item: Zotero.Item) {
-    await syncNote(this.notion, item);
+    await syncNoteItem(this.notion, item);
   }
 }

--- a/src/content/sync/sync-job.ts
+++ b/src/content/sync/sync-job.ts
@@ -1,6 +1,7 @@
 import { type Client } from '@notionhq/client';
 
 import { APA_STYLE } from '../constants';
+import { ItemSyncError } from '../errors';
 import {
   NoteroPref,
   PageTitleFormat,
@@ -81,18 +82,6 @@ async function retrieveDatabaseProperties(
   });
 
   return database.properties;
-}
-
-class ItemSyncError extends Error {
-  public readonly item: Zotero.Item;
-  public readonly name = 'ItemSyncError';
-
-  public constructor(cause: unknown, item: Zotero.Item) {
-    super(`Failed to sync item with ID ${item.id} due to ${String(cause)}`, {
-      cause,
-    });
-    this.item = item;
-  }
 }
 
 async function syncItems(

--- a/src/content/sync/sync-note-item.ts
+++ b/src/content/sync/sync-note-item.ts
@@ -35,12 +35,12 @@ import { isArchivedOrNotFoundError } from './notion-utils';
  *      supports notes within synced blocks as the synced block is used as the
  *      container rather than the top-level container.
  *
- * @param notion an initialized Notion `Client` instance
  * @param noteItem the Zotero note item to sync to Notion
+ * @param notion an initialized Notion `Client` instance
  */
 export async function syncNoteItem(
-  notion: Client,
   noteItem: Zotero.Item,
+  notion: Client,
 ): Promise<void> {
   if (noteItem.isTopLevelItem()) {
     throw new LocalizableError(

--- a/src/content/sync/sync-note-item.ts
+++ b/src/content/sync/sync-note-item.ts
@@ -1,5 +1,5 @@
-import { Client, isFullBlock } from '@notionhq/client';
-import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+import { type Client, isFullBlock } from '@notionhq/client';
+import type { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
 import {
   getNotionPageID,
@@ -38,7 +38,7 @@ import { isArchivedOrNotFoundError } from './notion-utils';
  * @param notion an initialized Notion `Client` instance
  * @param noteItem the Zotero note item to sync to Notion
  */
-export async function syncNote(
+export async function syncNoteItem(
   notion: Client,
   noteItem: Zotero.Item,
 ): Promise<void> {

--- a/src/content/sync/sync-regular-item.ts
+++ b/src/content/sync/sync-regular-item.ts
@@ -1,0 +1,65 @@
+import { APIErrorCode, type Client, isFullPage } from '@notionhq/client';
+import type {
+  CreatePageResponse,
+  UpdatePageResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+import {
+  getNotionPageID,
+  saveNotionLinkAttachment,
+  saveNotionTag,
+} from '../data/item-data';
+import { LocalizableError } from '../errors';
+import { logger } from '../utils';
+
+import { convertWebURLToAppURL, isNotionErrorWithCode } from './notion-utils';
+import { buildProperties, PropertyBuilderParams } from './property-builder';
+
+type SyncRegularItemParams = PropertyBuilderParams & {
+  databaseID: string;
+  notion: Client;
+};
+
+export async function syncRegularItem(
+  params: SyncRegularItemParams,
+): Promise<void> {
+  const response = await saveItemToDatabase(params);
+
+  await saveNotionTag(params.item);
+
+  if (isFullPage(response)) {
+    const appURL = convertWebURLToAppURL(response.url);
+    await saveNotionLinkAttachment(params.item, appURL);
+  } else {
+    throw new LocalizableError(
+      'Failed to create Notion link attachment',
+      'notero-error-notion-link-attachment',
+    );
+  }
+}
+
+async function saveItemToDatabase(
+  params: SyncRegularItemParams,
+): Promise<CreatePageResponse & UpdatePageResponse> {
+  const { databaseID, item, notion } = params;
+  const pageID = getNotionPageID(item);
+
+  const properties = await buildProperties(params);
+
+  if (pageID) {
+    try {
+      logger.debug('Update page', pageID, properties);
+      return await notion.pages.update({ page_id: pageID, properties });
+    } catch (error) {
+      if (!isNotionErrorWithCode(error, APIErrorCode.ObjectNotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  logger.debug('Create page', properties);
+  return await notion.pages.create({
+    parent: { database_id: databaseID },
+    properties,
+  });
+}


### PR DESCRIPTION
Fixes #241 

Previously, changing the selected destination Notion database did not have the desired effect for items that had been synced to the previous database because Notero would continue to sync to the page in the previous database. To remedy this, we now do the following during the sync process:

- Recreate Notion pages when found in a different database
- Reset synced notes when page ID changes

This PR also includes a number of refactors. See the commits for details.