### PR TITLE
fix(sync): Do not sync note items when "sync notes" is disabled

### DIFF
--- a/src/content/services/__tests__/sync-manager.spec.ts
+++ b/src/content/services/__tests__/sync-manager.spec.ts
@@ -423,6 +423,18 @@ describe('SyncManager', () => {
       expect(performSyncJob).toHaveBeenCalledTimes(0);
     });
 
+    it('does not perform sync of note item when `syncNotes` is disabled', () => {
+      const { eventManager } = setup({ syncNotes: false });
+
+      eventManager.emit('notifier-event', 'item.modify', [
+        outOfSyncNoteItem.id,
+      ]);
+
+      vi.runAllTimers();
+
+      expect(performSyncJob).toHaveBeenCalledTimes(0);
+    });
+
     it('does not perform sync when item is deleted', () => {
       const { eventManager } = setup();
 

--- a/src/content/services/sync-manager.ts
+++ b/src/content/services/sync-manager.ts
@@ -100,6 +100,7 @@ export class SyncManager implements Service {
     ...[event, ids]: NotifierEventParams
   ): Zotero.Item[] {
     const syncOnModifyItems = getNoteroPref(NoteroPref.syncOnModifyItems);
+    const syncNotes = getNoteroPref(NoteroPref.syncNotes);
 
     if (!syncOnModifyItems && event !== 'collection-item.add') {
       return [];
@@ -115,7 +116,9 @@ export class SyncManager implements Service {
         return items.concat(notes);
       }
       case 'item.modify': {
-        const items = Zotero.Items.get(ids);
+        const items = Zotero.Items.get(ids).filter(
+          (item) => item.isRegularItem() || (item.isNote() && syncNotes),
+        );
         const notes = this.getNotesToSync(items);
         return items.concat(notes);
       }


### PR DESCRIPTION
Fixes #509

When note items were modified, they would be synced regardless of whether the "sync notes" option was enabled. This PR fixes that so that notes only sync:

- when "sync notes" is enabled and a note item is modified, or
- when a note item is specifically requested for sync via the context menu—regardless of the "sync notes" option