### PR TITLE
docs(README): Use latest connection copy from Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ installing the Notero plugin in Zotero. Detailed setup instructions are below.
 
     > 1. Go to the database page in your workspace.
     > 2. Click on the **•••** More menu in the top-right corner of the page.
-    > 3. Scroll down to and click **+ Add Connections**.
+    > 3. Scroll down to and click **Connect to**.
     > 4. Search for and select your integration in the **Search for connections...** menu.
 
       <details>


### PR DESCRIPTION
The connections menu in Notion now says "Connect to" instead of "Add Connections"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for connecting Notion integration to the Notero plugin for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->