### PR TITLE
feat: Add option to select url schema (notion: or https:)

### DIFF
--- a/src/content/prefs/notero-pref.ts
+++ b/src/content/prefs/notero-pref.ts
@@ -8,6 +8,7 @@ export enum NoteroPref {
   pageTitleFormat = 'pageTitleFormat',
   syncNotes = 'syncNotes',
   syncOnModifyItems = 'syncOnModifyItems',
+  urlSchema = 'urlSchema',
 }
 
 export enum PageTitleFormat {
@@ -17,6 +18,11 @@ export enum PageTitleFormat {
   itemInTextCitation = 'itemInTextCitation',
   itemShortTitle = 'itemShortTitle',
   itemTitle = 'itemTitle',
+}
+
+export enum UrlSchema {
+  notion = 'notion',
+  https = 'https',
 }
 
 export const PAGE_TITLE_FORMAT_L10N_IDS: Record<
@@ -42,6 +48,7 @@ type NoteroPrefValue = Partial<{
   [NoteroPref.pageTitleFormat]: PageTitleFormat;
   [NoteroPref.syncNotes]: boolean;
   [NoteroPref.syncOnModifyItems]: boolean;
+  [NoteroPref.urlSchema]: UrlSchema;
 }>;
 
 function buildFullPrefName(pref: NoteroPref): string {
@@ -54,6 +61,12 @@ function getBooleanPref(value: Zotero.Prefs.Value): boolean | undefined {
 
 function getStringPref(value: Zotero.Prefs.Value): string | undefined {
   return typeof value === 'string' && value ? value : undefined;
+}
+
+function getUrlSchemaPref(value: Zotero.Prefs.Value): UrlSchema | undefined {
+  return Object.values(UrlSchema).includes(value as UrlSchema)
+    ? (value as UrlSchema)
+    : undefined;
 }
 
 function isPageTitleFormat(
@@ -82,6 +95,9 @@ function convertRawPrefValue<P extends NoteroPref>(
     (pref === NoteroPref.pageTitleFormat && getPageTitleFormatPref(value)) ||
     undefined;
 
+  const urlSchemaPref =
+    (pref === NoteroPref.urlSchema && getUrlSchemaPref(value)) || undefined;
+
   return {
     [NoteroPref.collectionSyncConfigs]: stringPref,
     [NoteroPref.notionDatabaseID]: stringPref,
@@ -89,6 +105,7 @@ function convertRawPrefValue<P extends NoteroPref>(
     [NoteroPref.pageTitleFormat]: pageTitleFormatPref,
     [NoteroPref.syncNotes]: booleanPref,
     [NoteroPref.syncOnModifyItems]: booleanPref,
+    [NoteroPref.urlSchema]: urlSchemaPref,
   }[pref];
 }
 

--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -18,7 +18,11 @@ import {
   logger,
 } from '../utils';
 
-import { PAGE_TITLE_FORMAT_L10N_IDS, PageTitleFormat } from './notero-pref';
+import {
+  PAGE_TITLE_FORMAT_L10N_IDS,
+  PageTitleFormat,
+  UrlSchema,
+} from './notero-pref';
 import { SyncConfigsTable } from './sync-configs-table';
 
 type ReactDOMClient = typeof ReactDOM & { createRoot: typeof createRoot };
@@ -57,6 +61,7 @@ class Preferences {
   private notionError!: XUL.LabelElement;
   private notionWorkspaceLabel!: XUL.LabelElement;
   private pageTitleFormatMenu!: XUL.MenuListElement;
+  private urlSchemaMenu!: XUL.MenuListElement;
 
   public async init(): Promise<void> {
     await Zotero.uiReadyPromise;
@@ -79,6 +84,7 @@ class Preferences {
     this.notionDatabaseMenu = getXULElementById('notero-notionDatabase')!;
     this.notionError = getXULElementById('notero-notionError')!;
     this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat')!;
+    this.urlSchemaMenu = getXULElementById('notero-urlSchema')!;
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     window.addEventListener('unload', () => {
@@ -87,6 +93,7 @@ class Preferences {
 
     await this.initPageTitleFormatMenu();
     await this.initSyncConfigsTable();
+    this.initUrlSchemaMenu();
 
     // Don't block window from loading while waiting for network responses
     setTimeout(() => {
@@ -104,6 +111,18 @@ class Preferences {
       'notion-connection.add',
       this.handleNotionConnectionAdd,
     );
+  }
+
+  private initUrlSchemaMenu(): void {
+    const menuItems = Object.values(UrlSchema).map<MenuItem>((schema) => ({
+      disabled: false,
+      label: `${schema}://`,
+      value: schema,
+    }));
+
+    setMenuItems(this.urlSchemaMenu, menuItems);
+    this.urlSchemaMenu.disabled = false;
+    this.urlSchemaMenu.value = UrlSchema.notion; // Set default value to Notion schema
   }
 
   private async initPageTitleFormatMenu(): Promise<void> {

--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -75,6 +75,27 @@
 
 <groupbox class="notero-groupbox">
   <label>
+    <html:h2 data-l10n-id="notero-preferences-links-groupbox-heading" />
+  </label>
+  <label data-l10n-id="notero-preferences-links-groupbox-description" />
+  <separator class="thin" />
+  <hbox align="center">
+    <label
+      control="notero-urlSchema"
+      data-l10n-id="notero-preferences-links-url-schema"
+    />
+    <menulist
+      id="notero-urlSchema"
+      native="true"
+      preference="extensions.notero.urlSchema"
+    >
+      <menupopup />
+    </menulist>
+  </hbox>
+</groupbox>
+
+<groupbox class="notero-groupbox">
+  <label>
     <html:h2 data-l10n-id="notero-preferences-sync-groupbox-heading" />
   </label>
   <label data-l10n-id="notero-preferences-sync-groupbox-description1" />

--- a/src/content/sync/sync-regular-item.ts
+++ b/src/content/sync/sync-regular-item.ts
@@ -7,6 +7,7 @@ import {
   saveNotionTag,
 } from '../data/item-data';
 import { LocalizableError } from '../errors';
+import { getNoteroPref, NoteroPref, UrlSchema } from '../prefs/notero-pref';
 import { logger } from '../utils';
 
 import type { DatabaseRequestProperties } from './notion-types';
@@ -28,8 +29,12 @@ export async function syncRegularItem(
   await saveNotionTag(item);
 
   if (isFullPage(response)) {
-    const appURL = convertWebURLToAppURL(response.url);
-    await saveNotionLinkAttachment(item, appURL);
+    // Decide link schema based on user preference
+    const notionURL =
+      getNoteroPref(NoteroPref.urlSchema) === UrlSchema.notion
+        ? convertWebURLToAppURL(response.url)
+        : response.url;
+    await saveNotionLinkAttachment(item, notionURL);
   } else {
     throw new LocalizableError(
       'Failed to create Notion link attachment',

--- a/src/locale/en-US/notero.ftl
+++ b/src/locale/en-US/notero.ftl
@@ -26,6 +26,11 @@ notero-preferences-properties-groupbox-heading = Property Preferences
 notero-preferences-properties-groupbox-description = Customize how item properties sync to Notion.
 notero-preferences-page-title-format = Notion Page Title:
 
+## Link preferences
+notero-preferences-links-groupbox-heading = Link Preferences
+notero-preferences-links-groupbox-description = Define if links are saved as notion:// or https:// links. Note that notion:// links are only accessible if the desktop app is installed.
+notero-preferences-links-url-schema = URL Schema:
+
 ## Page title format options
 
 notero-page-title-format-item-author-date-citation =


### PR DESCRIPTION
Hi there!

This PR should address the feature request in #53.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/fc5f125c-9325-4094-8ef3-56c79d327c77" />

I added a new field in the Notero preferences page that allows the user to choose whether to use https or notion url schema. Whenever an item is created, this preference is checked and the url is build accordingly. Interestingly, if the user changes the option, all URLs will be updated to match the desired schema.

I would really appreciate your opinion on two things @dvanoni :
- I set the current default to the notion schema. Is that good?
- We may want to improve the explanation in the preference section. Any suggestion?

Happy to hear your thoughts!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added URL schema preference for link handling
	- Users can now choose between Notion app links (notion://) and web links (https://)

- **Documentation**
	- Added localization strings explaining URL schema preferences
	- Provided clear user guidance about link saving options

- **User Interface**
	- Introduced new preference section for link configuration
	- Added menu for selecting preferred URL schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->