### PR TITLE
feat(preferences): Add input for pasting Notion connection token

### DIFF
--- a/src/content/prefs/preferences.tsx
+++ b/src/content/prefs/preferences.tsx
@@ -52,6 +52,7 @@ class Preferences {
   private notionConnectionContainer!: XUL.XULElement;
   private notionConnectionSpinner!: XUL.XULElement;
   private notionConnectButton!: XUL.ButtonElement;
+  private notionDisconnectButton!: XUL.ButtonElement;
   private notionUpgradeConnectionButton!: XUL.ButtonElement;
   private notionDatabaseMenu!: XUL.MenuListElement;
   private notionError!: XUL.LabelElement;
@@ -72,6 +73,7 @@ class Preferences {
       'notero-notionConnection-spinner',
     )!;
     this.notionConnectButton = getXULElementById('notero-notionConnect')!;
+    this.notionDisconnectButton = getXULElementById('notero-notionDisconnect')!;
     this.notionUpgradeConnectionButton = getXULElementById(
       'notero-notionUpgradeConnection',
     )!;
@@ -80,6 +82,18 @@ class Preferences {
     this.notionError = getXULElementById('notero-notionError')!;
     this.pageTitleFormatMenu = getXULElementById('notero-pageTitleFormat')!;
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    /* eslint-disable @typescript-eslint/no-misused-promises */
+    this.notionConnectButton.addEventListener('command', this.connectNotion);
+    this.notionDisconnectButton.addEventListener(
+      'command',
+      this.disconnectNotion,
+    );
+    this.notionUpgradeConnectionButton.addEventListener(
+      'command',
+      this.upgradeNotionConnection,
+    );
+    /* eslint-enable @typescript-eslint/no-misused-promises */
 
     window.addEventListener('unload', () => {
       this.deinit();
@@ -255,7 +269,7 @@ class Preferences {
     return databases;
   }
 
-  public async connectNotion(event: XUL.CommandEvent): Promise<void> {
+  private connectNotion = async (event: XUL.CommandEvent): Promise<void> => {
     const button = event.target as XUL.ButtonElement;
 
     button.disabled = true;
@@ -269,9 +283,9 @@ class Preferences {
     );
 
     await this.notionAuthManager.openLogin();
-  }
+  };
 
-  public async disconnectNotion(): Promise<void> {
+  private disconnectNotion = async (): Promise<void> => {
     const dialogTitle =
       (await document.l10n.formatValue(
         'notero-preferences-notion-disconnect-dialog-title',
@@ -287,9 +301,11 @@ class Preferences {
     await this.notionAuthManager.removeAllConnections();
 
     await this.refreshNotionConnectionSection();
-  }
+  };
 
-  public async upgradeNotionConnection(event: XUL.CommandEvent): Promise<void> {
+  private upgradeNotionConnection = async (
+    event: XUL.CommandEvent,
+  ): Promise<void> => {
     const dialogTitle =
       (await document.l10n.formatValue(
         'notero-preferences-notion-upgrade-dialog-title',
@@ -306,7 +322,7 @@ class Preferences {
     setTimeout(() => {
       void this.connectNotion(event);
     }, 100);
-  }
+  };
 }
 
 module.exports = {

--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -12,7 +12,6 @@
       data-l10n-id="notero-preferences-notion-connect-button"
       hidden="true"
       id="notero-notionConnect"
-      oncommand="notero.preferences.connectNotion(event);"
     />
   </hbox>
   <image class="zotero-spinner-16" id="notero-notionConnection-spinner" />
@@ -25,11 +24,10 @@
       <button
         data-l10n-id="notero-preferences-notion-upgrade-button"
         id="notero-notionUpgradeConnection"
-        oncommand="notero.preferences.upgradeNotionConnection(event);"
       />
       <button
         data-l10n-id="notero-preferences-notion-disconnect-button"
-        oncommand="notero.preferences.disconnectNotion();"
+        id="notero-notionDisconnect"
       />
     </hbox>
     <hbox align="center" class="notero-margin-block-start">

--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -32,8 +32,7 @@
         oncommand="notero.preferences.disconnectNotion();"
       />
     </hbox>
-    <separator class="thin" />
-    <hbox align="center">
+    <hbox align="center" class="notero-margin-block-start">
       <label
         control="notero-notionDatabase"
         data-l10n-id="notero-preferences-notion-database"
@@ -56,8 +55,7 @@
     <html:h2 data-l10n-id="notero-preferences-properties-groupbox-heading" />
   </label>
   <label data-l10n-id="notero-preferences-properties-groupbox-description" />
-  <separator class="thin" />
-  <hbox align="center">
+  <hbox align="center" class="notero-margin-block-start">
     <label
       control="notero-pageTitleFormat"
       data-l10n-id="notero-preferences-page-title-format"
@@ -79,11 +77,12 @@
   </label>
   <label data-l10n-id="notero-preferences-sync-groupbox-description1" />
   <label data-l10n-id="notero-preferences-sync-groupbox-description2" />
-  <separator class="thin" />
-  <hbox class="virtualized-table-container" flex="1">
+  <hbox
+    class="notero-margin-block-start notero-margin-block-end virtualized-table-container"
+    flex="1"
+  >
     <html:div id="notero-syncConfigsTable-container" />
   </hbox>
-  <separator class="thin" />
   <checkbox
     data-l10n-id="notero-preferences-sync-on-modify-items"
     id="notero-syncOnModifyItems"

--- a/src/content/prefs/preferences.xhtml
+++ b/src/content/prefs/preferences.xhtml
@@ -9,12 +9,29 @@
   </label>
   <hbox>
     <button
+      class="notero-margin-block-end"
       data-l10n-id="notero-preferences-notion-connect-button"
       hidden="true"
       id="notero-notionConnect"
     />
   </hbox>
   <image class="zotero-spinner-16" id="notero-notionConnection-spinner" />
+  <hbox
+    align="center"
+    class="notero-margin-block-end"
+    hidden="true"
+    id="notero-notionToken-container"
+  >
+    <label
+      control="notero-notionToken"
+      data-l10n-id="notero-preferences-notion-token-label"
+    />
+    <html:input
+      data-l10n-id="notero-preferences-notion-token-input"
+      id="notero-notionToken"
+      type="text"
+    />
+  </hbox>
   <vbox align="start" hidden="true" id="notero-notionConnection-container">
     <hbox align="center">
       <label

--- a/src/content/style/preferences.css
+++ b/src/content/style/preferences.css
@@ -11,6 +11,14 @@
   max-width: 100%;
 }
 
+.notero-margin-block-start {
+  margin-block-start: 0.5em;
+}
+
+.notero-margin-block-end {
+  margin-block-end: 0.5em;
+}
+
 #notero-notionDatabase {
   overflow: hidden;
 }

--- a/src/content/style/preferences.css
+++ b/src/content/style/preferences.css
@@ -19,6 +19,11 @@
   margin-block-end: 0.5em;
 }
 
+#notero-notionToken {
+  flex: 1;
+  font-family: monospace;
+}
+
 #notero-notionDatabase {
   overflow: hidden;
 }

--- a/src/locale/en-US/notero.ftl
+++ b/src/locale/en-US/notero.ftl
@@ -17,6 +17,9 @@ notero-preferences-notion-disconnect-dialog-text = Disconnecting your Notion wor
 notero-preferences-notion-upgrade-button = Upgrade Connection…
 notero-preferences-notion-upgrade-dialog-title = Upgrade Notion Connection
 notero-preferences-notion-upgrade-dialog-text = Notero has evolved into a Notion public integration, enabling enhanced features and security. To upgrade, click OK and you'll be redirected to Notion to authorize the new Notero integration. After completing this one-time process, you can safely delete your previous internal integration. See the Notero README for more details.
+notero-preferences-notion-token-label = Connection Token:
+notero-preferences-notion-token-input =
+    .placeholder = Paste your connection token here
 notero-preferences-notion-workspace = Workspace: { $workspace-name }
 notero-preferences-notion-database = Database:
 


### PR DESCRIPTION
Fixes #639 

https://github.com/dvanoni/notero-auth/commit/43b52c20d6749ffa024f93d451d47a367ce42166 provides a fallback option to copy the Notion connection token. A new input field in the Notero preferences allows pasting the token to complete the connection process.

https://github.com/user-attachments/assets/567bc8cd-5273-4a6e-b24d-40152fe01b45

