### PR TITLE
ci(dependabot): Ignore major React versions to follow Zotero

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
       typescript-eslint:
         patterns:
           - '@typescript-eslint*'
+    ignore:
+      # Ignore major React versions to follow Zotero
+      - dependency-name: 'react*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Use Dependabot [`ignore`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) option to ignore major version updates to React so that we stay in sync with Zotero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to prevent automatic major version updates for React and related type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->