### PR TITLE
build(deps-dev): Remove deprecated @types/eslint__js package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@fluent/syntax": "^0.19.0",
         "@total-typescript/ts-reset": "^0.6.1",
         "@types/adm-zip": "^0.5.7",
-        "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/fs-extra": "^11.0.4",
         "@types/jsdom": "^21.1.7",
@@ -1694,25 +1693,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint__js": {
-      "version": "8.42.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
-      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*"
       }
     },
     "node_modules/@types/eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@fluent/syntax": "^0.19.0",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/adm-zip": "^0.5.7",
-    "@types/eslint__js": "^8.42.3",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/fs-extra": "^11.0.4",
     "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
The `@types/eslint__js` package was deprecated via https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71994 and is no longer needed now that types for `@eslint/js` were added in https://github.com/eslint/eslint/pull/19010.