### PR TITLE
fix(preferences): Fix Notion connection URL handler in Zotero 8

### DIFF
--- a/src/content/services/__tests__/protocol-handler-extension.spec.ts
+++ b/src/content/services/__tests__/protocol-handler-extension.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { DeepMockProxy, mock } from 'vitest-mock-extended';
+
+import type { NotionAuthManager } from '../../auth';
+import { logger } from '../../utils';
+import {
+  ProtocolHandlerExtension,
+  parseHandlerNameFromPathname,
+} from '../protocol-handler-extension';
+
+const pluginInfo = {
+  pluginID: 'test',
+  rootURI: 'test',
+  version: 'test',
+};
+
+function setup() {
+  const zoteroProtocolHandler = mock<Zotero.ZoteroProtocolHandler>();
+  const servicesMock = Services as DeepMockProxy<typeof Services>;
+  servicesMock.io.getProtocolHandler.mockReturnValue(
+    mock<XPCOM.nsIProtocolHandler>({ wrappedJSObject: zoteroProtocolHandler }),
+  );
+
+  const notionAuthManager = mock<NotionAuthManager>();
+  const protocolHandlerExtension = new ProtocolHandlerExtension();
+
+  const dependencies = { notionAuthManager };
+
+  protocolHandlerExtension.startup({ dependencies, pluginInfo });
+
+  return { notionAuthManager, protocolHandlerExtension, zoteroProtocolHandler };
+}
+
+describe('parseHandlerNameFromPathname', () => {
+  // Zotero 7 behavior
+  it('returns handler name when host and pathname are present', () => {
+    const handlerName = parseHandlerNameFromPathname('//notero/notion-auth');
+    expect(handlerName).toBe('notion-auth');
+  });
+
+  // Zotero 7 behavior
+  it('returns undefined when only host is present', () => {
+    const handlerName = parseHandlerNameFromPathname('//notero');
+    expect(handlerName).toBeUndefined();
+  });
+
+  // Zotero 8 behavior
+  it('returns handler name when only pathname is present', () => {
+    const handlerName = parseHandlerNameFromPathname('/notion-auth');
+    expect(handlerName).toBe('notion-auth');
+  });
+
+  // Zotero 8 behavior
+  it('returns undefined when pathname is empty', () => {
+    const handlerName = parseHandlerNameFromPathname('');
+    expect(handlerName).toBeUndefined();
+  });
+});
+
+describe('ProtocolHandlerExtension', () => {
+  it('registers upon startup', () => {
+    const { zoteroProtocolHandler } = setup();
+
+    expect(zoteroProtocolHandler._extensions['zotero://notero']).toBeTruthy();
+  });
+
+  it('unregisters upon shutdown', () => {
+    const { protocolHandlerExtension, zoteroProtocolHandler } = setup();
+
+    expect(zoteroProtocolHandler._extensions['zotero://notero']).toBeTruthy();
+
+    protocolHandlerExtension.shutdown();
+
+    expect(
+      zoteroProtocolHandler._extensions['zotero://notero'],
+    ).toBeUndefined();
+  });
+
+  it('logs warning if no handler matches URI', () => {
+    const { zoteroProtocolHandler } = setup();
+
+    const uri = mock<XPCOM.nsIURI>({ spec: 'zotero://notero/bogus' });
+
+    zoteroProtocolHandler._extensions['zotero://notero']?.newChannel(uri, {});
+
+    expect(logger.warn).toHaveBeenCalledWith('No handler with name:', 'bogus');
+  });
+
+  it('calls NotionAuthManager.handleTokenResponse with provided URI params', () => {
+    const { notionAuthManager, zoteroProtocolHandler } = setup();
+
+    const uri = mock<XPCOM.nsIURI>({
+      spec: 'zotero://notero/notion-auth?key1=val1&key2=val2',
+    });
+
+    zoteroProtocolHandler._extensions['zotero://notero']?.newChannel(uri, {});
+
+    const expectedParams = new URLSearchParams({ key1: 'val1', key2: 'val2' });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(notionAuthManager.handleTokenResponse).toHaveBeenCalledWith(
+      expectedParams,
+    );
+  });
+});


### PR DESCRIPTION
I discovered that Zotero 7 and Zotero 8 parse URLs differently. For example, the URL `zotero://notero/notion-auth` results in the following:

- Zotero 7: `{ host: '', pathname: '//notero/notion-auth' }`
- Zotero 8: `{ host: 'notero', pathname: '/notion-auth' }`

This meant the Notion connection URL handler (`notion-auth`) was not correctly invoked in Zotero 8.

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of protocol URIs to better support different Zotero versions.
  * Enhanced error and warning messages for unmatched or invalid protocol handlers.

* **Tests**
  * Added comprehensive tests for protocol handler functionality and URI parsing, including interactions with authentication and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->