### PR TITLE
fix(preferences): Do not show deleted collections in sync table

### DIFF
--- a/src/content/prefs/sync-configs-table.tsx
+++ b/src/content/prefs/sync-configs-table.tsx
@@ -94,6 +94,7 @@ export class SyncConfigsTable extends React.Component<Props> {
 
   private buildRows(): SyncConfigsTableRow[] {
     return Zotero.Collections.getLoaded()
+      .filter((collection) => !collection.deleted)
       .map((collection) => ({
         collection,
         collectionFullName: buildCollectionFullName(collection),


### PR DESCRIPTION
Fixes #775 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Deleted collections are no longer displayed in the sync configurations table, ensuring only active collections appear in your configuration view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->