### PR TITLE
chore: Mark as compatible with Zotero 9.0.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "name": "Notero",
     "updateURL": "https://github.com/dvanoni/notero/releases/download/release/updates.json",
     "zoteroMinVersion": "7.0",
-    "zoteroMaxVersion": "8.0.*",
+    "zoteroMaxVersion": "9.0.*",
     "zotero6": {
       "version": "0.5.17",
       "updateLink": "https://github.com/dvanoni/notero/releases/download/v0.5.17/notero-0.5.17.xpi"


### PR DESCRIPTION
See Zotero 9 announcements:

- [dev list post](https://groups.google.com/g/zotero-dev/c/QrwXJseBzuA)
- [blog post](https://www.zotero.org/blog/zotero-9/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended extension compatibility to support Zotero version 9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->