### PR TITLE
ci: Only use pre-release versions on `build` job

### DIFF
--- a/scripts/utils/version.mts
+++ b/scripts/utils/version.mts
@@ -30,8 +30,8 @@ function computeVersion(): string {
 
   if (!GITHUB_ACTIONS) return getLocalVersion();
 
-  const isPublish = GITHUB_JOB === 'publish-artifacts';
-  if (isPublish) return pkg.version;
+  const isBuildJob = GITHUB_JOB === 'build';
+  if (!isBuildJob) return pkg.version;
 
   const isReleasePR = Boolean(GITHUB_HEAD_REF?.startsWith('release-please'));
   const baseVersion = isReleasePR ? pkg.version : getPatchBumpVersion();


### PR DESCRIPTION
Fix an issue discovered when #816 was run—specifically that it used a pre-release version instead of the version in `package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build pipeline configuration for version handling during release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->