### PR TITLE
fix(sync): Support new `app.notion.com` URLs

### DIFF
--- a/src/content/data/item-data.ts
+++ b/src/content/data/item-data.ts
@@ -1,5 +1,5 @@
 import { NOTION_TAG_NAME } from '../constants';
-import { getPageIDFromURL, isNotionURL } from '../sync/notion-utils';
+import { getPageIDFromURL, isNotionPageURL } from '../sync/notion-utils';
 import { isObject } from '../utils';
 
 const SYNCED_NOTES_ID = 'notero-synced-notes';
@@ -22,7 +22,7 @@ function getAllNotionLinkAttachments(item: Zotero.Item): Zotero.Item[] {
     .toSorted((a, b) => b - a);
 
   return Zotero.Items.get(attachmentIDs).filter((attachment) =>
-    isNotionURL(attachment.getField('url')),
+    isNotionPageURL(attachment.getField('url')),
   );
 }
 

--- a/src/content/sync/notion-utils/__tests__/url.spec.ts
+++ b/src/content/sync/notion-utils/__tests__/url.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { getPageIDFromURL, isNotionPageURL } from '../url';
+
+describe('getPageIDFromURL', () => {
+  it('returns undefined for a www.notion.so URL with an invalid page ID', () => {
+    const url = 'https://www.notion.so/invalid-page-id';
+    expect(getPageIDFromURL(url)).toBeUndefined();
+  });
+
+  it('returns page ID for a www.notion.so app URL', () => {
+    const url =
+      'notion://www.notion.so/page-title-here-34028626a44f8144b2f3ea986abcd5f9';
+    expect(getPageIDFromURL(url)).toBe('34028626a44f8144b2f3ea986abcd5f9');
+  });
+
+  it('returns page ID for a www.notion.so web URL', () => {
+    const url =
+      'https://www.notion.so/page-title-here-34028626a44f8144b2f3ea986abcd5f9';
+    expect(getPageIDFromURL(url)).toBe('34028626a44f8144b2f3ea986abcd5f9');
+  });
+
+  it('returns undefined for a app.notion.com URL with an invalid page ID', () => {
+    const url = 'https://app.notion.com/invalid-page-id';
+    expect(getPageIDFromURL(url)).toBeUndefined();
+  });
+
+  it('returns page ID for an app.notion.com app URL', () => {
+    const url =
+      'notion://app.notion.com/page-title-here-34028626a44f8144b2f3ea986abcd5f9';
+    expect(getPageIDFromURL(url)).toBe('34028626a44f8144b2f3ea986abcd5f9');
+  });
+
+  it('returns page ID for an app.notion.com web URL', () => {
+    const url =
+      'https://app.notion.com/page-title-here-34028626a44f8144b2f3ea986abcd5f9';
+    expect(getPageIDFromURL(url)).toBe('34028626a44f8144b2f3ea986abcd5f9');
+  });
+});
+
+describe('isNotionPageURL', () => {
+  it('returns false for a non-Notion URL', () => {
+    const url = 'https://www.example.com';
+    expect(isNotionPageURL(url)).toBe(false);
+  });
+
+  it.each([
+    [
+      false,
+      'www.notion.so URL with an invalid page ID',
+      'https://www.notion.so/invalid-page-id',
+    ],
+    [
+      true,
+      'www.notion.so app URL',
+      'notion://www.notion.so/page-title-here-34028626a44f8144b2f3ea986abcd5f9',
+    ],
+    [
+      true,
+      'www.notion.so web URL',
+      'https://www.notion.so/page-title-here-34028626a44f8144b2f3ea986abcd5f9',
+    ],
+    [
+      false,
+      'app.notion.com URL with an invalid page ID',
+      'https://app.notion.com/invalid-page-id',
+    ],
+    [
+      true,
+      'app.notion.com app URL',
+      'notion://app.notion.com/page-title-here-34028626a44f8144b2f3ea986abcd5f9',
+    ],
+    [
+      true,
+      'app.notion.com web URL',
+      'https://app.notion.com/page-title-here-34028626a44f8144b2f3ea986abcd5f9',
+    ],
+  ])('returns %s for a %s', (expected, _description, url) => {
+    expect(isNotionPageURL(url)).toBe(expected);
+  });
+});

--- a/src/content/sync/notion-utils/__tests__/url.spec.ts
+++ b/src/content/sync/notion-utils/__tests__/url.spec.ts
@@ -39,6 +39,13 @@ describe('getPageIDFromURL', () => {
 });
 
 describe('isNotionPageURL', () => {
+  it.each([undefined, null, 123, {}])(
+    'returns false for non-string input: %s',
+    (value) => {
+      expect(isNotionPageURL(value)).toBe(false);
+    },
+  );
+
   it('returns false for a non-Notion URL', () => {
     const url = 'https://www.example.com';
     expect(isNotionPageURL(url)).toBe(false);

--- a/src/content/sync/notion-utils/index.ts
+++ b/src/content/sync/notion-utils/index.ts
@@ -2,4 +2,8 @@ export { buildDate } from './build-date';
 export { buildRichText } from './build-rich-text';
 export { isArchivedOrNotFoundError, isNotionErrorWithCode } from './error';
 export { normalizeID } from './normalize-id';
-export { convertWebURLToAppURL, getPageIDFromURL, isNotionURL } from './url';
+export {
+  convertWebURLToAppURL,
+  getPageIDFromURL,
+  isNotionPageURL,
+} from './url';

--- a/src/content/sync/notion-utils/url.ts
+++ b/src/content/sync/notion-utils/url.ts
@@ -3,7 +3,7 @@ const WEB_URL_PROTOCOL = 'https:';
 const WEB_URL_PROTOCOL_REGEX = new RegExp(`^${WEB_URL_PROTOCOL}`);
 
 const PAGE_URL_REGEX = new RegExp(
-  `^(?:${APP_URL_PROTOCOL}|${WEB_URL_PROTOCOL})//www.notion.so/.*([0-9a-f]{32})$`,
+  `^(?:${APP_URL_PROTOCOL}|${WEB_URL_PROTOCOL})//(?:www.notion.so|app.notion.com)/.*([0-9a-f]{32})$`,
 );
 
 export function convertWebURLToAppURL(url: string): string {

--- a/src/content/sync/notion-utils/url.ts
+++ b/src/content/sync/notion-utils/url.ts
@@ -15,7 +15,7 @@ export function getPageIDFromURL(url: string): string | undefined {
   return matches ? matches[1] : undefined;
 }
 
-export function isNotionURL(value: unknown): value is string {
+export function isNotionPageURL(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   return PAGE_URL_REGEX.test(value);
 }


### PR DESCRIPTION
Fixes #823 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Notion link detection to consistently recognize page links across both www.notion.so and app.notion.com, ensuring correct handling of page URLs.

* **Tests**
  * Added comprehensive tests for Notion URL parsing and page ID extraction, covering multiple domain and protocol formats and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->