### PR TITLE
ci: Migrate to `client-id` for generating Notero Bot app token

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -15,8 +15,8 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.NOTERO_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.NOTERO_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.NOTERO_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.NOTERO_BOT_PRIVATE_KEY }}
       - id: release-please
         uses: googleapis/release-please-action@v5
         with:


### PR DESCRIPTION
`client-id` replaces `app-id` which was deprecated in https://github.com/actions/create-github-app-token/pull/353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflow configurations to use new authentication credentials for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->