### PR TITLE
ci: Update Crowdin workflow to weekly on Saturday

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '34 12 * * *' # Run every day at 12:34 UTC
+    - cron: '34 12 * * 6' # Run every week on Saturday at 12:34 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Previously ran daily at 12:34 UTC; now runs weekly on Saturday at 12:34 UTC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated scheduled workflow frequency from daily to weekly, running every Saturday at 12:34 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->