### PR TITLE
feat: Save Notion web URLs instead of desktop app URLs

### DIFF
--- a/src/content/data/item-data.ts
+++ b/src/content/data/item-data.ts
@@ -39,7 +39,7 @@ export function getNotionPageID(item: Zotero.Item): string | undefined {
 
 export async function saveNotionLinkAttachment(
   item: Zotero.Item,
-  appURL: string,
+  url: string,
 ): Promise<void> {
   const attachments = getAllNotionLinkAttachments(item);
 
@@ -54,13 +54,13 @@ export async function saveNotionLinkAttachment(
   if (attachment) {
     const currentURL = attachment.getField('url');
     pageIDChanged =
-      !currentURL || getPageIDFromURL(currentURL) !== getPageIDFromURL(appURL);
-    attachment.setField('url', appURL);
+      !currentURL || getPageIDFromURL(currentURL) !== getPageIDFromURL(url);
+    attachment.setField('url', url);
   } else {
     attachment = await Zotero.Attachments.linkFromURL({
       parentItemID: item.id,
       title: 'Notion',
-      url: appURL,
+      url,
       saveOptions: {
         skipNotifier: true,
       },

--- a/src/content/sync/__tests__/sync-regular-item.spec.ts
+++ b/src/content/sync/__tests__/sync-regular-item.spec.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from 'vite-plus/test';
 import { mockDeep } from 'vitest-mock-extended';
 
 import { createZoteroItemMock } from '../../../../test/utils';
-import { getNotionPageID } from '../../data/item-data';
+import {
+  getNotionPageID,
+  saveNotionLinkAttachment,
+} from '../../data/item-data';
 import { PageTitleFormat } from '../../prefs/notero-pref';
 import type { DatabaseRequestProperties } from '../notion-types';
 import { buildProperties } from '../property-builder';
@@ -33,7 +36,7 @@ const validationError = new APIResponseError({
 const fakeCitationFormat = 'fake-style';
 const fakeDatabaseID = 'fake-database-id';
 const fakeDatabaseProperties = {};
-const fakePageID = 'fake-page-id';
+const fakePageID = '34028626a44f8144b2f3ea986abcd5f9';
 const fakePageProperties: DatabaseRequestProperties = { title: { title: [] } };
 const fakePageTitleFormat = PageTitleFormat.itemAuthorDateCitation;
 const fakePageResponse: PageObjectResponse = {
@@ -50,7 +53,7 @@ const fakePageResponse: PageObjectResponse = {
   parent: { database_id: fakeDatabaseID, type: 'database_id' },
   properties: {},
   public_url: null,
-  url: 'fake-url',
+  url: `https://app.notion.com/page-title-here-${fakePageID}`,
 };
 
 function setup({ pageID }: { pageID?: string }) {
@@ -157,6 +160,17 @@ describe('syncRegularItem', () => {
       parent: { database_id: fakeDatabaseID },
       properties: fakePageProperties,
     });
+  });
+
+  it('saves Notion link attachment using exact URL from response', async () => {
+    const { params, regularItem } = setup({ pageID: fakePageID });
+
+    await syncRegularItem(regularItem, params);
+
+    expect(saveNotionLinkAttachment).toHaveBeenCalledExactlyOnceWith(
+      regularItem,
+      fakePageResponse.url,
+    );
   });
 
   it('throws error when validation error is not caused by differing database', async () => {

--- a/src/content/sync/notion-utils/index.ts
+++ b/src/content/sync/notion-utils/index.ts
@@ -2,8 +2,4 @@ export { buildDate } from './build-date';
 export { buildRichText } from './build-rich-text';
 export { isArchivedOrNotFoundError, isNotionErrorWithCode } from './error';
 export { normalizeID } from './normalize-id';
-export {
-  convertWebURLToAppURL,
-  getPageIDFromURL,
-  isNotionPageURL,
-} from './url';
+export { getPageIDFromURL, isNotionPageURL } from './url';

--- a/src/content/sync/notion-utils/url.ts
+++ b/src/content/sync/notion-utils/url.ts
@@ -1,14 +1,9 @@
 const APP_URL_PROTOCOL = 'notion:';
 const WEB_URL_PROTOCOL = 'https:';
-const WEB_URL_PROTOCOL_REGEX = new RegExp(`^${WEB_URL_PROTOCOL}`);
 
 const PAGE_URL_REGEX = new RegExp(
   `^(?:${APP_URL_PROTOCOL}|${WEB_URL_PROTOCOL})//(?:www.notion.so|app.notion.com)/.*([0-9a-f]{32})$`,
 );
-
-export function convertWebURLToAppURL(url: string): string {
-  return url.replace(WEB_URL_PROTOCOL_REGEX, APP_URL_PROTOCOL);
-}
 
 export function getPageIDFromURL(url: string): string | undefined {
   const matches = url.match(PAGE_URL_REGEX);

--- a/src/content/sync/sync-regular-item.ts
+++ b/src/content/sync/sync-regular-item.ts
@@ -11,7 +11,6 @@ import { logger } from '../utils';
 
 import type { DatabaseRequestProperties } from './notion-types';
 import {
-  convertWebURLToAppURL,
   isArchivedOrNotFoundError,
   isNotionErrorWithCode,
   normalizeID,
@@ -28,8 +27,7 @@ export async function syncRegularItem(
   await saveNotionTag(item);
 
   if (isFullPage(response)) {
-    const appURL = convertWebURLToAppURL(response.url);
-    await saveNotionLinkAttachment(item, appURL);
+    await saveNotionLinkAttachment(item, response.url);
   } else {
     throw new LocalizableError(
       'Failed to create Notion link attachment',


### PR DESCRIPTION
When saving Notion page URLs as item attachments, we now save the original `https:` URL instead of converting it to a `notion:` desktop app URL. This supports users who prefer the Notion web app, and it takes advantage of Notion's own [setting for opening links in the desktop app](https://www.notion.com/help/account-settings#open-links-in-desktop-app).

If "open links in desktop app" is enabled on macOS, the behavior is the same as before because Notion web URLs open the desktop app via [universal links](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content).

Resolves #53, Closes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Notion link attachments now store the Notion-created page URL directly and use a streamlined page-ID detection approach.
* **Tests**
  * Sync tests updated to assert the exact page URL is saved when creating or updating attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->